### PR TITLE
TECH-1104: fix missing variable name error

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    exception_handling (1.2.3)
+    exception_handling (1.2.4)
       actionmailer (~> 3.2)
       actionpack (~> 3.2)
       activesupport (~> 3.2)
@@ -111,7 +111,7 @@ GEM
     treetop (1.4.15)
       polyglot
       polyglot (>= 0.3.1)
-    tzinfo (0.3.48)
+    tzinfo (0.3.51)
 
 PLATFORMS
   ruby

--- a/lib/exception_handling.rb
+++ b/lib/exception_handling.rb
@@ -172,7 +172,7 @@ EOF
       write_exception_to_log(exception, custom_description, timestamp)
 
       if honeybadger?
-        send_exception_to_honeybadger(ex, exception_data, nil, timestamp)
+        send_exception_to_honeybadger(exception, exception_data, nil, timestamp)
       end
 
       if should_send_email?

--- a/lib/exception_handling/version.rb
+++ b/lib/exception_handling/version.rb
@@ -1,3 +1,3 @@
 module ExceptionHandling
-  VERSION = "1.2.3"
+  VERSION = "1.2.4"
 end

--- a/test/unit/exception_handling_test.rb
+++ b/test/unit/exception_handling_test.rb
@@ -130,7 +130,7 @@ class ExceptionHandlingTest < ActiveSupport::TestCase
         mock(ExceptionHandling.logger).fatal(/\(blah\):\n.*exception_handling_test\.rb/)
         ExceptionHandling.ensure_safe { raise ArgumentError.new("blah") }
       end
-      
+
       should "log an exception with call stack if an ActionView template exception is raised." do
         mock(ExceptionHandling.logger).fatal(/\(Error:\d+\) ActionView::Template::Error  \(blah\):\n  <no backtrace>/)
         ExceptionHandling.ensure_safe { raise ActionView::TemplateError.new({}, {}, ArgumentError.new("blah")) }
@@ -400,6 +400,11 @@ class ExceptionHandlingTest < ActiveSupport::TestCase
         should "invoke send_exception_to_honeybadger when log_error is executed" do
           ExceptionHandling.expects(:send_exception_to_honeybadger).times(1)
           ExceptionHandling.log_error(exception_1)
+        end
+
+        should "invoke send_exception_to_honeybadger when log_error_rack is executed" do
+          ExceptionHandling.expects(:send_exception_to_honeybadger).times(1)
+          ExceptionHandling.log_error_rack(exception_1, {}, nil)
         end
 
         should "invoke send_exception_to_honeybadger when ensure_safe is executed" do


### PR DESCRIPTION
@jebentier can you take a look at this small fix? Is it ok to leave the gem version as it is right now?