### PR TITLE
1612/eb/tech-1191 ability to suppress honeybadger exceptions

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    exception_handling (1.2.5)
+    exception_handling (1.2.6)
       actionmailer (~> 3.2)
       actionpack (~> 3.2)
       activesupport (~> 3.2)

--- a/lib/exception_handling.rb
+++ b/lib/exception_handling.rb
@@ -113,8 +113,7 @@ module ExceptionHandling # never included
     #
     def log_error_rack(exception, env, rack_filter)
       timestamp = set_log_error_timestamp
-      controller = env['action_controller.instance']
-      exception_info = ExceptionInfo.new(exception, env, timestamp, controller)
+      exception_info = ExceptionInfo.new(exception, env, timestamp)
 
       if stub_handler
         return stub_handler.handle_stub_log_error(exception_info.data)
@@ -132,7 +131,7 @@ module ExceptionHandling # never included
 
       if should_send_email?
         # controller may not exist in some cases (like most 404 errors)
-        if controller
+        if (controller = exception_info.controller)
           controller.session["last_exception_timestamp"] = ExceptionHandling.last_exception_timestamp
         end
         log_error_email(exception_info)

--- a/lib/exception_handling.rb
+++ b/lib/exception_handling.rb
@@ -132,7 +132,7 @@ module ExceptionHandling # never included
       if should_send_email?
         # controller may not exist in some cases (like most 404 errors)
         if (controller = exception_info.controller)
-          controller.session["last_exception_timestamp"] = ExceptionHandling.last_exception_timestamp
+          controller.session["last_exception_timestamp"] = last_exception_timestamp
         end
         log_error_email(exception_info)
       end
@@ -241,13 +241,13 @@ module ExceptionHandling # never included
     def escalate_error(exception_or_string, email_subject)
       ex = make_exception(exception_or_string)
       log_error(ex)
-      escalate(email_subject, ex, ExceptionHandling.last_exception_timestamp)
+      escalate(email_subject, ex, last_exception_timestamp)
     end
 
     def escalate_warning(message, email_subject)
       ex = Warning.new(message)
       log_error(ex)
-      escalate(email_subject, ex, ExceptionHandling.last_exception_timestamp)
+      escalate(email_subject, ex, last_exception_timestamp)
     end
 
     def ensure_escalation(email_subject)

--- a/lib/exception_handling/exception_description.rb
+++ b/lib/exception_handling/exception_description.rb
@@ -3,13 +3,14 @@ module ExceptionHandling
     MATCH_SECTIONS =  [:error, :request, :session, :environment, :backtrace, :event_response]
 
     CONFIGURATION_SECTIONS = {
-        send_email:  false,  # should email be sent?
-        send_metric: true,   # should the metric be sent.
-        metric_name: nil,    # Will be derived from section name if not passed
-        notes:       nil     # Will be included in exception email if set, used to keep notes and relevant links
+        send_email:           false,  # should email be sent?
+        send_to_honeybadger:  true,   # should be sent to honeybadger?
+        send_metric:          true,   # should the metric be sent.
+        metric_name:          nil,    # Will be derived from section name if not passed
+        notes:                nil     # Will be included in exception email if set, used to keep notes and relevant links
     }
 
-    attr_reader :filter_name, :send_email, :send_metric, :metric_name, :notes
+    attr_reader :filter_name, :send_email, :send_to_honeybadger, :send_metric, :metric_name, :notes
 
     def initialize(filter_name, configuration)
       @filter_name = filter_name
@@ -19,6 +20,7 @@ module ExceptionHandling
 
       @configuration = CONFIGURATION_SECTIONS.merge(configuration)
       @send_email  = @configuration[:send_email]
+      @send_to_honeybadger = @configuration[:send_to_honeybadger]
       @send_metric = @configuration[:send_metric]
       @metric_name = (@configuration[:metric_name] || @filter_name ).to_s.gsub(" ","_")
       @notes       = @configuration[:notes]

--- a/lib/exception_handling/exception_info.rb
+++ b/lib/exception_handling/exception_info.rb
@@ -1,0 +1,231 @@
+module ExceptionHandling
+
+  class ExceptionInfo
+
+    ENVIRONMENT_WHITELIST = [
+      /^HTTP_/,
+      /^QUERY_/,
+      /^REQUEST_/,
+      /^SERVER_/
+    ]
+
+    ENVIRONMENT_OMIT =(
+<<EOF
+CONTENT_TYPE: application/x-www-form-urlencoded
+GATEWAY_INTERFACE: CGI/1.2
+HTTP_ACCEPT: */*
+HTTP_ACCEPT: */*, text/javascript, text/html, application/xml, text/xml, */*
+HTTP_ACCEPT_CHARSET: ISO-8859-1,utf-8;q=0.7,*;q=0.7
+HTTP_ACCEPT_ENCODING: gzip, deflate
+HTTP_ACCEPT_ENCODING: gzip,deflate
+HTTP_ACCEPT_LANGUAGE: en-us
+HTTP_CACHE_CONTROL: no-cache
+HTTP_CONNECTION: Keep-Alive
+HTTP_HOST: www.invoca.com
+HTTP_MAX_FORWARDS: 10
+HTTP_UA_CPU: x86
+HTTP_VERSION: HTTP/1.1
+HTTP_X_FORWARDED_HOST: www.invoca.com
+HTTP_X_FORWARDED_SERVER: www2.invoca.com
+HTTP_X_REQUESTED_WITH: XMLHttpRequest
+LANG:
+PATH: /sbin:/usr/sbin:/bin:/usr/bin
+PWD: /
+RAILS_ENV: production
+RAW_POST_DATA: id=500
+REMOTE_ADDR: 10.251.34.225
+SCRIPT_NAME: /
+SERVER_NAME: www.invoca.com
+SERVER_PORT: 80
+SERVER_PROTOCOL: HTTP/1.1
+SERVER_SOFTWARE: Mongrel 1.1.4
+SHLVL: 1
+TERM: linux
+TERM: xterm-color
+_: /usr/bin/mongrel_cluster_ctl
+EOF
+      ).split("\n")
+
+    SECTIONS = [:request, :session, :environment, :backtrace, :event_response]
+    HONEYBADGER_CONTEXT_SECTIONS = [:timestamp, :error_class, :server, :scm_revision, :notes, :user_details, :request, :session, :environment, :backtrace, :event_response]
+
+    attr_reader :exception
+
+    def initialize(exception, exception_context, timestamp, controller = nil, data_callback = nil)
+      @exception = exception
+      @exception_context = exception_context
+      @timestamp = timestamp
+      @controller = controller
+      @data_callback = data_callback
+    end
+
+    def data
+      @data ||= exception_to_data
+    end
+
+    def enhanced_data
+      @enhanced_data ||= exception_to_enhanced_data
+    end
+
+    def exception_catalog
+      @exception_catalog ||= ExceptionCatalog.new(ExceptionHandling.filter_list_filename)
+    end
+
+    def exception_description
+      @exception_description ||= exception_catalog.find(enhanced_data)
+    end
+
+    def exception_filter_name
+    end
+
+    def send_to_honeybadger?
+      ExceptionHandling.honeybadger? && (!exception_description || exception_description.send_to_honeybadger)
+    end
+
+    private
+
+    def exception_to_data
+      data = ActiveSupport::HashWithIndifferentAccess.new
+      data[:error_class] = @exception.class.name
+      data[:error_string]= "#{data[:error_class]}: #{ExceptionHandling.encode_utf8(@exception.message)}"
+      data[:timestamp]   = @timestamp
+      data[:backtrace]   = ExceptionHandling.clean_backtrace(@exception)
+      if @exception_context && @exception_context.is_a?(Hash)
+        # if we are a hash, then we got called from the DebugExceptions rack middleware filter
+        # and we need to do some things different to get the info we want
+        data[:error] = "#{data[:error_class]}: #{ExceptionHandling.encode_utf8(@exception.message)}"
+        data[:session] = @exception_context['rack.session']
+        data[:environment] = @exception_context
+      else
+        data[:error]       = "#{data[:error_string]}#{': ' + @exception_context.to_s unless @exception_context.blank?}"
+        data[:environment] = { message: @exception_context }
+      end
+      data
+    end
+
+    def exception_to_enhanced_data
+      enhanced_data = exception_to_data
+      extract_and_merge_controller_data(enhanced_data)
+      customize_from_data_callback(enhanced_data)
+      enhance_exception_data(enhanced_data)
+      normalize_exception_data(enhanced_data)
+      clean_exception_data(enhanced_data)
+
+      description = exception_catalog.find(enhanced_data)
+      merged_data = description ? ActiveSupport::HashWithIndifferentAccess.new(description.exception_data.merge(enhanced_data)) : enhanced_data
+    end
+
+    def enhance_exception_data(data)
+      return if ! ExceptionHandling.custom_data_hook
+      begin
+        ExceptionHandling.custom_data_hook.call(data)
+      rescue Exception => ex
+        # can't call log_error here or we will blow the call stack
+        traces = ex.backtrace.map { |l| "#{l}\n" }.join
+        ExceptionHandling.log_info("Unable to execute custom custom_data_hook callback. #{ExceptionHandling.encode_utf8(ex.message)} #{traces}")
+      end
+    end
+
+    def normalize_exception_data(data)
+      if data[:location].nil?
+        data[:location] = {}
+        if data[:request] && data[:request].key?(:params)
+          data[:location][:controller] = data[:request][:params]['controller']
+          data[:location][:action]     = data[:request][:params]['action']
+        end
+      end
+      if data[:backtrace] && data[:backtrace].first
+        first_line = data[:backtrace].first
+
+        # template exceptions have the line number and filename as the first element in backtrace
+        if matched = first_line.match( /on line #(\d*) of (.*)/i )
+          backtrace_hash = {}
+          backtrace_hash[:line] = matched[1]
+          backtrace_hash[:file] = matched[2]
+        else
+          backtrace_hash = Hash[* [:file, :line].zip( first_line.split( ':' )[0..1]).flatten ]
+        end
+
+        data[:location].merge!( backtrace_hash )
+      end
+      SECTIONS.each { |section| add_to_s( data[section] ) if data[section].is_a? Hash }
+    end
+
+    def clean_exception_data( data )
+      if (as_array = data[:backtrace].to_a).size == 1
+        data[:backtrace] = as_array.first.to_s.split(/\n\s*/)
+      end
+
+      if data[:request].is_a?(Hash) && data[:request][:params].is_a?(Hash)
+        data[:request][:params] = clean_params(data[:request][:params])
+      end
+
+      if data[:environment].is_a?(Hash)
+        data[:environment] = clean_environment(data[:environment])
+      end
+    end
+
+    def clean_params(params)
+      params.each do |k, v|
+        params[k] = "[FILTERED]" if k =~ /password/
+      end
+    end
+
+    def clean_environment(env)
+      Hash[ env.map do |k, v|
+        [k, v] if !"#{k}: #{v}".in?(ENVIRONMENT_OMIT) && ENVIRONMENT_WHITELIST.any? { |regex| k =~ regex }
+      end.compact ]
+    end
+
+    #
+    # Pull certain fields out of the controller and add to the data hash.
+    #
+    def extract_and_merge_controller_data(data)
+      if @controller
+        data[:request] = {
+          params:      @controller.request.parameters.to_hash,
+          rails_root:  defined?(Rails) ? Rails.root : "Rails.root not defined. Is this a test environment?",
+          url:         @controller.complete_request_uri
+        }
+        data[:environment].merge!(@controller.request.env.to_hash)
+
+        @controller.session[:fault_in_session]
+        data[:session] = {
+          key:         @controller.request.session_options[:id],
+          data:        @controller.session.dup
+        }
+      end
+    end
+
+    def customize_from_data_callback(data)
+      if @data_callback
+        # the expectation is that if the caller passed a block then they will be
+        # doing their own merge of hash values into data
+        begin
+          @data_callback.call(data)
+        rescue Exception => ex
+          data.merge!(environment: "Exception in yield: #{ex.class}:#{ex}")
+        end
+      end
+    end
+
+    def add_to_s( data_section )
+      data_section[:to_s] = dump_hash( data_section )
+    end
+
+    def dump_hash( h, indent_level = 0 )
+      result = ""
+      h.sort { |a, b| a.to_s <=> b.to_s }.each do |key, value|
+        result << ' ' * (2 * indent_level)
+        result << "#{key}:"
+        case value
+        when Hash
+          result << "\n" << dump_hash( value, indent_level + 1 )
+        else
+          result << " #{value}\n"
+        end
+      end unless h.nil?
+      result
+    end
+  end
+end

--- a/lib/exception_handling/exception_info.rb
+++ b/lib/exception_handling/exception_info.rb
@@ -48,13 +48,13 @@ EOF
     SECTIONS = [:request, :session, :environment, :backtrace, :event_response]
     HONEYBADGER_CONTEXT_SECTIONS = [:timestamp, :error_class, :server, :scm_revision, :notes, :user_details, :request, :session, :environment, :backtrace, :event_response]
 
-    attr_reader :exception
+    attr_reader :exception, :controller
 
     def initialize(exception, exception_context, timestamp, controller = nil, data_callback = nil)
       @exception = exception
       @exception_context = exception_context
       @timestamp = timestamp
-      @controller = controller
+      @controller = controller || controller_from_context(exception_context)
       @data_callback = data_callback
     end
 
@@ -83,6 +83,10 @@ EOF
     end
 
     private
+
+    def controller_from_context(exception_context)
+      exception_context.is_a?(Hash) ? exception_context["action_controller.instance"] : nil
+    end
 
     def exception_to_data
       data = ActiveSupport::HashWithIndifferentAccess.new

--- a/lib/exception_handling/version.rb
+++ b/lib/exception_handling/version.rb
@@ -1,3 +1,3 @@
 module ExceptionHandling
-  VERSION = "1.2.5"
+  VERSION = "1.2.6"
 end

--- a/test/helpers/controller_helpers.rb
+++ b/test/helpers/controller_helpers.rb
@@ -1,0 +1,9 @@
+module ControllerHelpers
+  DummyController = Struct.new(:complete_request_uri, :request, :session)
+  DummyRequest = Struct.new(:env, :parameters, :session_options)
+
+  def create_dummy_controller(env, parameters, session, request_uri)
+    request = DummyRequest.new(env, parameters, session)
+    DummyController.new(request_uri, request, session)
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -149,6 +149,10 @@ def assert_equal_with_diff arg1, arg2, msg = ''
   end
 end
 
+def require_test_helper(helper_path)
+  require_relative "helpers/#{helper_path}"
+end
+
 class Time
   class << self
     attr_reader :now_override

--- a/test/unit/exception_handling/exception_description_test.rb
+++ b/test/unit/exception_handling/exception_description_test.rb
@@ -29,6 +29,12 @@ module ExceptionHandling
         assert !ExceptionDescription.new(:filter1, error: "my error message" ).send_email
       end
 
+      should "allow send_to_honeybadger to be specified and have it enabled by default" do
+        assert !ExceptionDescription.new(:filter1, error: "my error message", send_to_honeybadger: false).send_to_honeybadger
+        assert ExceptionDescription.new(:filter1, error: "my error message", send_to_honeybadger: true).send_to_honeybadger
+        assert ExceptionDescription.new(:filter1, error: "my error message").send_to_honeybadger
+      end
+
       should "allow send_metric to be configured" do
         assert !ExceptionDescription.new(:filter1, error: "my error message", send_metric: false ).send_metric
         assert ExceptionDescription.new(:filter1, error: "my error message", send_email: true ).send_metric

--- a/test/unit/exception_handling/exception_info_test.rb
+++ b/test/unit/exception_handling/exception_info_test.rb
@@ -134,6 +134,28 @@ module ExceptionHandling
         assert_equal_with_diff expected_data, prepare_data(exception_info.enhanced_data)
       end
 
+      should "extract controller from rack specific exception context when not provided explicitly" do
+        @exception_context["action_controller.instance"] = @controller
+        exception_info = ExceptionInfo.new(@exception, @exception_context, @timestamp)
+        expected_data = {
+          "error_class" => "StandardError",
+          "error_string" => "StandardError: something went wrong",
+          "timestamp" => @timestamp,
+          "backtrace" => ["<no backtrace>"],
+          "error" => "StandardError: something went wrong",
+          "session" => { "key" => "session_key", "data" => { "username" => "jsmith", "id" => "session_key" } },
+          "environment" => { "SERVER_NAME" => "exceptional.com" },
+          "request" => {
+            "params" => { "advertiser_id" => 435, "controller" => "dummy", "action" => "fail" },
+            "rails_root" => "Rails.root not defined. Is this a test environment?",
+            "url" => "host/path"
+          },
+          "location" => { "controller" => "dummy", "action" => "fail", "file" => "<no backtrace>", "line" => nil }
+        }
+
+        assert_equal_with_diff expected_data, prepare_data(exception_info.enhanced_data)
+      end
+
       should "add to_s attribute to specific sections that have their content in hash format" do
         exception_info = ExceptionInfo.new(@exception, @exception_context, @timestamp, @controller)
         expected_data = {

--- a/test/unit/exception_handling/exception_info_test.rb
+++ b/test/unit/exception_handling/exception_info_test.rb
@@ -1,0 +1,224 @@
+require File.expand_path('../../../test_helper',  __FILE__)
+
+module ExceptionHandling
+  class ExceptionInfoTest < ActiveSupport::TestCase
+
+    DummyController = Struct.new(:complete_request_uri, :request, :session)
+
+    DummyRequest = Struct.new(:env, :parameters, :session_options)
+
+    context "data" do
+      setup do
+        @exception = StandardError.new("something went wrong")
+        @timestamp = Time.now
+      end
+
+      should "return a hash with exception specific data including context hash" do
+        exception_context = {
+          "rack.session" => {
+            user_id: 23,
+            user_name: "John"
+          }
+        }
+
+        exception_info = ExceptionInfo.new(@exception, exception_context, @timestamp)
+        expected_data = {
+          "error_class" => "StandardError",
+          "error_string" => "StandardError: something went wrong",
+          "timestamp" => @timestamp,
+          "backtrace" => ["<no backtrace>"],
+          "error" => "StandardError: something went wrong",
+          "session" => { "user_id" => 23, "user_name" => "John" },
+          "environment" => {
+            "rack.session" => { "user_id" => 23, "user_name" => "John" }
+          }
+        }
+
+        assert_equal_with_diff expected_data, exception_info.data
+      end
+
+      should "return a hash with exception specific data including context string" do
+        exception_context = "custom context data"
+        exception_info = ExceptionInfo.new(@exception, exception_context, @timestamp)
+        expected_data = {
+          "error_class" => "StandardError",
+          "error_string" => "StandardError: something went wrong",
+          "timestamp" => @timestamp,
+          "backtrace" => ["<no backtrace>"],
+          "error" => "StandardError: something went wrong: custom context data",
+          "environment" => {
+            "message" => "custom context data"
+          }
+        }
+
+        assert_equal_with_diff expected_data, exception_info.data
+      end
+
+      should "not include enhanced data from controller or custom data callback" do
+        env = { server: "fe98" }
+        parameters = { advertiser_id: 435 }
+        session = { username: "jsmith" }
+        request_uri = "host/path"
+        controller = create_dummy_controller(env, parameters, session, request_uri)
+        data_callback = ->(data) { data[:custom_section] = "value" }
+        exception_info = ExceptionInfo.new(@exception, "custom context data", @timestamp, controller, data_callback)
+
+        dont_allow(exception_info).extract_and_merge_controller_data
+        dont_allow(exception_info).customize_from_data_callback
+        expected_data = {
+          "error_class" => "StandardError",
+          "error_string" => "StandardError: something went wrong",
+          "timestamp" => @timestamp,
+          "backtrace" => ["<no backtrace>"],
+          "error" => "StandardError: something went wrong: custom context data",
+          "environment" => {
+            "message" => "custom context data"
+          }
+        }
+
+        assert_equal_with_diff expected_data, exception_info.data
+      end
+    end
+
+    context "enhanced_data" do
+      setup do
+        @exception = StandardError.new("something went wrong")
+        @timestamp = Time.now
+        @exception_context = {
+          "rack.session" => {
+            user_id: 23,
+            user_name: "John"
+          },
+          "SERVER_NAME" => "exceptional.com"
+        }
+        env = { server: "fe98" }
+        parameters = { advertiser_id: 435, controller: "dummy", action: "fail" }
+        session = { username: "jsmith", id: "session_key" }
+        request_uri = "host/path"
+        @controller = create_dummy_controller(env, parameters, session, request_uri)
+        @data_callback = ->(data) { data[:custom_section] = "check this out" }
+      end
+
+      should "return a hash with generic exception attributes as well as context data" do
+        exception_info = ExceptionInfo.new(@exception, @exception_context, @timestamp)
+        expected_data = {
+          "error_class" => "StandardError",
+          "error_string" => "StandardError: something went wrong",
+          "timestamp" => @timestamp,
+          "backtrace" => ["<no backtrace>"],
+          "error" => "StandardError: something went wrong",
+          "session" => { "user_id" => 23, "user_name" => "John" },
+          "environment" => { "SERVER_NAME" => "exceptional.com" },
+          "location" => { "file" => "<no backtrace>", "line" => nil }
+        }
+
+        assert_equal_with_diff expected_data, exception_info.enhanced_data
+      end
+
+      should "include controller data when available" do
+        exception_info = ExceptionInfo.new(@exception, @exception_context, @timestamp, @controller)
+        expected_data = {
+          "error_class" => "StandardError",
+          "error_string" => "StandardError: something went wrong",
+          "timestamp" => @timestamp,
+          "backtrace" => ["<no backtrace>"],
+          "error" => "StandardError: something went wrong",
+          "session" => { "key" => "session_key", "data" => { "username" => "jsmith", "id" => "session_key" } },
+          "environment" => { "SERVER_NAME" => "exceptional.com" },
+          "request" => {
+            "params" => { "advertiser_id" => 435, "controller" => "dummy", "action" => "fail" },
+            "rails_root" => "Rails.root not defined. Is this a test environment?",
+            "url" => "host/path"
+          },
+          "location" => { "controller" => "dummy", "action" => "fail", "file" => "<no backtrace>", "line" => nil }
+        }
+
+        assert_equal_with_diff expected_data, exception_info.enhanced_data
+      end
+
+      should "include the changes from the custom data callback" do
+        exception_info = ExceptionInfo.new(@exception, @exception_context, @timestamp, nil, @data_callback)
+        expected_data = {
+          "error_class" => "StandardError",
+          "error_string" => "StandardError: something went wrong",
+          "timestamp" => @timestamp,
+          "backtrace" => ["<no backtrace>"],
+          "error" => "StandardError: something went wrong",
+          "session" => { "user_id" => 23, "user_name" => "John" },
+          "environment" => { "SERVER_NAME" => "exceptional.com" },
+          "custom_section" => "check this out",
+          "location" => { "file" => "<no backtrace>", "line" => nil }
+        }
+
+        assert_equal_with_diff expected_data, exception_info.enhanced_data
+      end
+
+      should "apply the custom_data_hook results" do
+        stub(ExceptionHandling).custom_data_hook { ->(data) { data[:custom_hook] = "changes from custom hook" } }
+        exception_info = ExceptionInfo.new(@exception, @exception_context, @timestamp)
+        expected_data = {
+          "error_class" => "StandardError",
+          "error_string" => "StandardError: something went wrong",
+          "timestamp" => @timestamp,
+          "backtrace" => ["<no backtrace>"],
+          "error" => "StandardError: something went wrong",
+          "session" => { "user_id" => 23, "user_name" => "John" },
+          "environment" => { "SERVER_NAME" => "exceptional.com" },
+          "custom_hook" => "changes from custom hook",
+          "location" => { "file" => "<no backtrace>", "line" => nil }
+        }
+
+        assert_equal_with_diff expected_data, exception_info.enhanced_data
+      end
+    end
+
+    should "return the exception description from the global exception filter list" do
+      exception = StandardError.new("No route matches")
+      exception_info = ExceptionInfo.new(exception, {}, Time.now)
+      description = exception_info.exception_description
+      assert_not_nil description
+      assert_equal :NoRoute, description.filter_name
+    end
+
+    context "send_to_honeybadger?" do
+      should "be enabled when Honeybadger is defined and exception is not in the filter list" do
+        stub(ExceptionHandling).honeybadger? { true }
+        exception = StandardError.new("something went wrong")
+        exception_info = ExceptionInfo.new(exception, {}, Time.now)
+        assert_nil exception_info.exception_description
+        assert_equal true, exception_info.send_to_honeybadger?
+      end
+
+      should "be enabled when Honeybadger is defined and exception is on the filter list with the flag turned on" do
+        stub(ExceptionHandling).honeybadger? { true }
+        exception = StandardError.new("No route matches")
+        exception_info = ExceptionInfo.new(exception, {}, Time.now)
+        assert_not_nil exception_info.exception_description
+        assert_equal true, exception_info.exception_description.send_to_honeybadger
+        assert_equal true, exception_info.send_to_honeybadger?
+      end
+
+      should "be disabled when Honeybadger is defined and exception is on the filter list with the flag turned off" do
+        stub(ExceptionHandling).honeybadger? { true }
+        exception = StandardError.new("No route matches")
+        exception_info = ExceptionInfo.new(exception, {}, Time.now)
+        assert_not_nil exception_info.exception_description
+        stub(exception_info.exception_description).send_to_honeybadger { false }
+        assert_equal false, exception_info.send_to_honeybadger?
+      end
+
+      should "be disabled when Honeybadger is not defined" do
+        stub(ExceptionHandling).honeybadger? { false }
+        exception = StandardError.new("something went wrong")
+        exception_info = ExceptionInfo.new(exception, {}, Time.now)
+        assert_nil exception_info.exception_description
+        assert_equal false, exception_info.send_to_honeybadger?
+      end
+    end
+
+    def create_dummy_controller(env, parameters, session, request_uri)
+      request = DummyRequest.new(env, parameters, session)
+      DummyController.new(request_uri, request, session)
+    end
+  end
+end

--- a/test/unit/exception_handling_test.rb
+++ b/test/unit/exception_handling_test.rb
@@ -494,6 +494,22 @@ class ExceptionHandlingTest < ActiveSupport::TestCase
           }
           assert_equal_with_diff expected_data, honeybadger_data
         end
+
+        should "not send notification to honeybadger when exception description has the flag turned off" do
+          filter_list = {
+            NoHoneybadger: {
+              error: "suppress Honeybadger notification",
+              send_to_honeybadger: false
+            }
+          }
+          stub(File).mtime { incrementing_mtime }
+          mock(YAML).load_file.with_any_args { ActiveSupport::HashWithIndifferentAccess.new(filter_list) }.at_least(1)
+
+          exception = StandardError.new("suppress Honeybadger notification")
+          mock.proxy(ExceptionHandling).send_exception_to_honeybadger.with_any_args.once
+          dont_allow(ExceptionHandling::Honeybadger).notify
+          ExceptionHandling.log_error(exception)
+        end
       end
     end
 

--- a/test/unit/exception_handling_test.rb
+++ b/test/unit/exception_handling_test.rb
@@ -1,6 +1,8 @@
 require File.expand_path('../../test_helper',  __FILE__)
+require_test_helper 'controller_helpers'
 
 class ExceptionHandlingTest < ActiveSupport::TestCase
+  include ControllerHelpers
 
   def dont_stub_log_error
     true
@@ -64,6 +66,11 @@ class ExceptionHandlingTest < ActiveSupport::TestCase
   end
 
   class SmtpClientErrbackStub < SmtpClientStub
+  end
+
+  class HoneybadgerStub
+    def self.notify(data)
+    end
   end
 
   context "#log_error" do
@@ -411,6 +418,11 @@ class ExceptionHandlingTest < ActiveSupport::TestCase
       context "with Honeybadger defined" do
         setup do
           stub(ExceptionHandling).honeybadger? { true }
+          ExceptionHandling.const_set('Honeybadger', HoneybadgerStub)
+        end
+
+        teardown do
+          ExceptionHandling.send(:remove_const, 'Honeybadger')
         end
 
         should "invoke send_exception_to_honeybadger when log_error is executed" do
@@ -426,6 +438,61 @@ class ExceptionHandlingTest < ActiveSupport::TestCase
         should "invoke send_exception_to_honeybadger when ensure_safe is executed" do
           ExceptionHandling.expects(:send_exception_to_honeybadger).times(1)
           ExceptionHandling.ensure_safe { raise exception_1 }
+        end
+
+        should "send error details and relevant context data to Honeybadger" do
+          Time.now_override = Time.now
+          env = { server: "fe98" }
+          parameters = { advertiser_id: 435 }
+          session = { username: "jsmith" }
+          request_uri = "host/path"
+          controller = create_dummy_controller(env, parameters, session, request_uri)
+          stub(ExceptionHandling).server_name { "invoca_fe98" }
+
+          exception = StandardError.new("Some BS")
+          exception.set_backtrace([
+            "test/unit/exception_handling_test.rb:847:in `exception_1'",
+            "test/unit/exception_handling_test.rb:455:in `block (4 levels) in <class:ExceptionHandlingTest>'"])
+          exception_context = { "SERVER_NAME" => "exceptional.com" }
+
+          honeybadger_data = nil
+          mock(ExceptionHandling::Honeybadger).notify.with_any_args do |data|
+            honeybadger_data = data
+          end
+          ExceptionHandling.log_error(exception, exception_context, controller) do |data|
+            data[:scm_revision] = "5b24eac37aaa91f5784901e9aabcead36fd9df82"
+            data[:user_details] = { username: "jsmith" }
+            data[:event_response] = "Event successfully received"
+            data[:other_section] = "This should not be included in the response"
+          end
+
+          expected_data = {
+            error_class: :"Test BS",
+            error_message: "Some BS",
+            exception: exception,
+            context: {
+              timestamp: Time.now.to_i,
+              error_class: "StandardError",
+              server: "invoca_fe98",
+              scm_revision: "5b24eac37aaa91f5784901e9aabcead36fd9df82",
+              notes: "this is used by a test",
+              user_details: { "username" => "jsmith" },
+              request: {
+                "params" => { "advertiser_id" => 435 },
+                "rails_root" => "Rails.root not defined. Is this a test environment?",
+                "url" => "host/path" },
+              session: {
+                "key" => nil,
+                "data" => { "username" => "jsmith" } },
+              environment: {
+                "SERVER_NAME" => "exceptional.com" },
+              backtrace: [
+                "test/unit/exception_handling_test.rb:847:in `exception_1'",
+                "test/unit/exception_handling_test.rb:455:in `block (4 levels) in <class:ExceptionHandlingTest>'"],
+              event_response: "Event successfully received"
+            }
+          }
+          assert_equal_with_diff expected_data, honeybadger_data
         end
       end
     end
@@ -767,13 +834,6 @@ class ExceptionHandlingTest < ActiveSupport::TestCase
       ensure
         Object.send(:remove_const, :Rails)
       end
-    end
-
-    should "clean params" do
-      p = {'password' => 'apple', 'username' => 'sam' }
-      ExceptionHandling.send( :clean_params, p )
-      assert_equal "[FILTERED]", p['password']
-      assert_equal 'sam', p['username']
     end
   end
 

--- a/views/exception_handling/mailer/exception_notification.html.erb
+++ b/views/exception_handling/mailer/exception_notification.html.erb
@@ -64,7 +64,7 @@
     <%= "#{ h location[:controller]}##{ h location[:action]}<br />".html_safe if location && location[:controller] -%>
     <%= "#{ h location[:file]}, line #{ h location[:line]}<br />".html_safe   if location && location[:file] -%>
 
-    <% for section in ExceptionHandling::SECTIONS %>
+    <% for section in ExceptionHandling::ExceptionInfo::SECTIONS %>
       <% section_value = @cleaned_data[section] %>
       <% if section_value %>
         <h3><%= section.to_s.capitalize -%>:</h3>

--- a/views/exception_handling/mailer/log_parser_exception_notification.html.erb
+++ b/views/exception_handling/mailer/log_parser_exception_notification.html.erb
@@ -58,7 +58,7 @@
 
 
 
-    <% for section in ExceptionHandling::SECTIONS %>
+    <% for section in ExceptionHandling::ExceptionInfo::SECTIONS %>
       <% section_value = @cleaned_data[section] %>
       <% if section_value %>
         <h3><%= section.to_s.capitalize -%>:</h3>


### PR DESCRIPTION
@mikeweaver can you please review? ([TECH-1191](https://ringrevenue.atlassian.net/browse/TECH-1191))
I moved the exception data logic to a single place so that it's shared between emails and honeybadger. The honebadger context now should support all the sections that were included in the emails.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/invoca/exception_handling/16)
<!-- Reviewable:end -->
