### PR TITLE
TECH-1862 - Allow multiline matches in exception filters

### DIFF
--- a/lib/exception_handling/exception_description.rb
+++ b/lib/exception_handling/exception_description.rb
@@ -27,7 +27,7 @@ module ExceptionHandling
 
       regex_config = @configuration.reject { |k,v| k.in?(CONFIGURATION_SECTIONS.keys) || v.blank? }
 
-      @regexes = Hash[regex_config.map { |section, regex| [section, Regexp.new(regex, 'i') ] }]
+      @regexes = Hash[regex_config.map { |section, regex| [section, Regexp.new(regex, Regexp::IGNORECASE | Regexp::MULTILINE) ] }]
 
       !@regexes.empty? or raise ArgumentError, "Filter #{filter_name} has all blank regexes: #{configuration.inspect}"
     end

--- a/test/unit/exception_handling/exception_description_test.rb
+++ b/test/unit/exception_handling/exception_description_test.rb
@@ -15,6 +15,11 @@ module ExceptionHandling
         assert @f.match?( :error => "my error message")
       end
 
+      should "allow wildcards to cross line boundries" do
+        @f = ExceptionDescription.new(:filter1, :error => "my error message.*with multiple lines" )
+        assert @f.match?( :error => "my error message\nwith more than one, with multiple lines")
+      end
+
       should "complain when no regexps have a value" do
         assert_raise(ArgumentError, "has all blank regexe") { ExceptionDescription.new(:filter1, error: nil) }
       end


### PR DESCRIPTION
@mikeweaver - I figured out why some of the exception filters are failing.  The exception text has newline characters.  You can't see this when you look at the honeybadger output, but the exceptions in NOC do preserver the newlines.   This change updates the filters to allow wildcards to cross newline boundaries.  