### PR TITLE
STORY-5399 log warnings should have empty array backtrace: have log_w…

### DIFF
--- a/lib/exception_handling.rb
+++ b/lib/exception_handling.rb
@@ -214,8 +214,10 @@ module ExceptionHandling # never included
       Object.const_defined?("Honeybadger")
     end
 
-    def log_warning( message )
-      log_error( Warning.new(message) )
+    def log_warning(message)
+      warning = Warning.new(message)
+      warning.set_backtrace([])
+      log_error(warning)
     end
 
     def log_info( message )

--- a/lib/exception_handling/methods.rb
+++ b/lib/exception_handling/methods.rb
@@ -16,9 +16,7 @@ module ExceptionHandling
     end
 
     def log_warning(message)
-      warning = Warning.new(message)
-      warning.set_backtrace([])
-      log_error(warning)
+      ExceptionHandling.log_warning(message)
     end
 
     def log_info(message)

--- a/lib/exception_handling/methods.rb
+++ b/lib/exception_handling/methods.rb
@@ -16,7 +16,9 @@ module ExceptionHandling
     end
 
     def log_warning(message)
-      log_error(Warning.new(message))
+      warning = Warning.new(message)
+      warning.set_backtrace([])
+      log_error(warning)
     end
 
     def log_info(message)

--- a/test/unit/exception_handling/methods_test.rb
+++ b/test/unit/exception_handling/methods_test.rb
@@ -67,6 +67,17 @@ module ExceptionHandling
         Rails.env = 'test'
         assert_equal 300, controller.send(:long_controller_action_timeout)
       end
+
+      context "#log_warning" do
+        should "be available to the controller" do
+          assert_equal true, @controller.methods.include?(:log_warning)
+        end
+
+        should "call ExceptionHandling#log_warning" do
+          mock(ExceptionHandling).log_warning("Hi mom")
+          @controller.send(:log_warning, "Hi mom")
+        end
+      end
     end
 
   end

--- a/test/unit/exception_handling_test.rb
+++ b/test/unit/exception_handling_test.rb
@@ -122,6 +122,17 @@ class ExceptionHandlingTest < ActiveSupport::TestCase
     end
   end
 
+
+  context "#log_warning" do
+    should "have empty array as a backtrace" do
+      mock(ExceptionHandling).log_error(is_a(ExceptionHandling::Warning)) do |error|
+        assert_equal ExceptionHandling::Warning, error.class
+        assert_equal [], error.backtrace
+      end
+      ExceptionHandling.log_warning('Now with empty array as a backtrace!')
+    end
+  end
+
   context "configuration" do
     should "support a custom_data_hook" do
       ExceptionHandling.custom_data_hook = method(:append_organization_info_config)

--- a/test/unit/exception_handling_test.rb
+++ b/test/unit/exception_handling_test.rb
@@ -126,7 +126,6 @@ class ExceptionHandlingTest < ActiveSupport::TestCase
   context "#log_warning" do
     should "have empty array as a backtrace" do
       mock(ExceptionHandling).log_error(is_a(ExceptionHandling::Warning)) do |error|
-        assert_equal ExceptionHandling::Warning, error.class
         assert_equal [], error.backtrace
       end
       ExceptionHandling.log_warning('Now with empty array as a backtrace!')


### PR DESCRIPTION
…arning raise an error with empty array backtrace

@nburwell 

Mind reviewing? This will allow log_warnings to have an empty array for a backtrace