### PR TITLE
WEB-3569 Allow catalog filepath to be updated

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -65,7 +65,7 @@ GIT
 PATH
   remote: .
   specs:
-    exception_handling (1.2.8)
+    exception_handling (1.2.9)
       actionmailer (~> 4.0)
       actionpack (~> 4.0)
       activesupport (~> 4.0)
@@ -81,7 +81,7 @@ GEM
     coderay (1.1.1)
     concurrent-ruby (1.0.4)
     erubis (2.7.0)
-    eventmachine (1.2.1)
+    eventmachine (1.2.5)
     globalid (0.3.7)
       activesupport (>= 4.1.0)
     i18n (0.7.0)

--- a/lib/exception_handling.rb
+++ b/lib/exception_handling.rb
@@ -110,6 +110,15 @@ module ExceptionHandling # never included
       @eventmachine_synchrony = bool
     end
 
+    def filter_list_filename=(filename)
+      @filter_list_filename = filename
+      @exception_catalog = nil
+    end
+
+    def exception_catalog
+      @exception_catalog ||= ExceptionCatalog.new(@filter_list_filename)
+    end
+
     #
     # internal settings (don't set directly)
     #

--- a/lib/exception_handling/exception_catalog.rb
+++ b/lib/exception_handling/exception_catalog.rb
@@ -16,14 +16,14 @@ module ExceptionHandling
 
     def refresh_filters
       mtime = last_modified_time
-      if @filters_last_modified_time.nil? || mtime != @filters_last_modified_time
+      if mtime && (@filters_last_modified_time.nil? || mtime != @filters_last_modified_time)
         ExceptionHandling.logger.info("Reloading filter list from: #{@filter_path}.  Last loaded time: #{@filters_last_modified_time}. Last modified time: #{mtime}")
         load_file
       end
 
     rescue => ex # any exceptions
       # DO NOT CALL ExceptionHandling.log_error because this method is called from that.  It can loop and cause mayhem.
-      ExceptionHandling.write_exception_to_log(ex, "ExceptionRegexes::refresh_filters: #{@filter_path}", Time.now.to_i)
+      ExceptionHandling.write_exception_to_log(ex, "ExceptionCatalog#refresh_filters: #{@filter_path}", Time.now.to_i)
     end
 
     def load_file
@@ -35,7 +35,7 @@ module ExceptionHandling
     end
 
     def last_modified_time
-      File.mtime(@filter_path)
+      @filter_path && File.mtime(@filter_path)
     end
   end
 end

--- a/lib/exception_handling/exception_catalog.rb
+++ b/lib/exception_handling/exception_catalog.rb
@@ -15,10 +15,11 @@ module ExceptionHandling
     private
 
     def refresh_filters
-      mtime = last_modified_time
-      if mtime && (@filters_last_modified_time.nil? || mtime != @filters_last_modified_time)
-        ExceptionHandling.logger.info("Reloading filter list from: #{@filter_path}.  Last loaded time: #{@filters_last_modified_time}. Last modified time: #{mtime}")
-        load_file
+      if (mtime = last_modified_time)
+        if @filters_last_modified_time.nil? || mtime != @filters_last_modified_time
+          ExceptionHandling.logger.info("Reloading filter list from: #{@filter_path}.  Last loaded time: #{@filters_last_modified_time}. Last modified time: #{mtime}")
+          load_file
+        end
       end
 
     rescue => ex # any exceptions

--- a/lib/exception_handling/exception_info.rb
+++ b/lib/exception_handling/exception_info.rb
@@ -66,12 +66,8 @@ EOF
       @enhanced_data ||= exception_to_enhanced_data
     end
 
-    def self.exception_catalog
-      @exception_catalog ||= ExceptionCatalog.new(ExceptionHandling.filter_list_filename)
-    end
-
     def exception_description
-      @exception_description ||= self.class.exception_catalog.find(enhanced_data)
+      @exception_description ||= ExceptionHandling.exception_catalog.find(enhanced_data)
     end
 
     def send_to_honeybadger?
@@ -117,7 +113,7 @@ EOF
       clean_exception_data(enhanced_data)
       stringify_sections(enhanced_data)
 
-      description = self.class.exception_catalog.find(enhanced_data)
+      description = ExceptionHandling.exception_catalog.find(enhanced_data)
       merged_data = description ? ActiveSupport::HashWithIndifferentAccess.new(description.exception_data.merge(enhanced_data)) : enhanced_data
     end
 

--- a/lib/exception_handling/version.rb
+++ b/lib/exception_handling/version.rb
@@ -1,3 +1,3 @@
 module ExceptionHandling
-  VERSION = "1.2.8"
+  VERSION = "1.2.9"
 end

--- a/test/unit/exception_handling/exception_catalog_test.rb
+++ b/test/unit/exception_handling/exception_catalog_test.rb
@@ -39,7 +39,7 @@ module ExceptionHandling
         @exception_catalog = ExceptionCatalog.new( ExceptionHandling.filter_list_filename )
 
         mock(ExceptionHandling).log_error.never
-        mock(ExceptionHandling).write_exception_to_log(anything(), "ExceptionRegexes::refresh_filters: ./config/exception_filters.yml", anything())
+        mock(ExceptionHandling).write_exception_to_log(anything(), "ExceptionCatalog#refresh_filters: ./config/exception_filters.yml", anything())
         mock(@exception_catalog).load_file { raise "noooooo"}
 
         @exception_catalog.find({})
@@ -59,6 +59,17 @@ module ExceptionHandling
       should "load the filter data" do
         assert !@exception_catalog.find( error: "Scott says unlikely to ever match" )
         assert !@exception_catalog.find( error: "Scott says unlikely to ever match" )
+      end
+    end
+
+    context "with no yaml content" do
+      setup do
+        @exception_catalog = ExceptionCatalog.new(nil)
+      end
+
+      should "not load filter data" do
+        mock(ExceptionHandling).write_exception_to_log.with_any_args.never
+        @exception_catalog.find( error: "Scott says unlikely to ever match" )
       end
     end
 


### PR DESCRIPTION
@ColinDKelley 
https://ringrevenue.atlassian.net/browse/WEB-3569
This change refactors how the ExceptionCatalog gets created and allows the filter_path to be nil. As it was this code made the ExceptionHandling initialization code very order sensitive. If the ExceptionHandling.filter_path_name was set after setting the server_name and setting the server_name via InvocaCluster.server_name caused a warning about 'Services Discovery Canary Mode' the ExceptionCatalog would have a filter_path of nil, which then caused an error on every reload attempt that then caused exceptions not to be logged. Any exception that was reported to ExceptionHandling before initialization would likely cause this problem. This convoluted chain of events took a long time to uncover and I don't want anyone else to have to go through it.