### PR TITLE
WEB-4024 exception handling is mutating user sessions

### DIFF
--- a/lib/exception_handling/exception_info.rb
+++ b/lib/exception_handling/exception_info.rb
@@ -193,7 +193,7 @@ EOF
         @controller.session[:fault_in_session]
         data[:session] = {
           key:         @controller.request.session_options[:id],
-          data:        @controller.session.dup
+          data:        @controller.session.to_hash
         }
       end
     end

--- a/test/helpers/controller_helpers.rb
+++ b/test/helpers/controller_helpers.rb
@@ -1,9 +1,27 @@
 module ControllerHelpers
   DummyController = Struct.new(:complete_request_uri, :request, :session)
   DummyRequest = Struct.new(:env, :parameters, :session_options)
+  
+  class DummySession
+    def initialize(data)
+      @data = data
+    end
+
+    def [](key)
+      @data[key]
+    end
+
+    def []=(key, value)
+      @data[key] = value
+    end
+
+    def to_hash
+      @data
+    end
+  end
 
   def create_dummy_controller(env, parameters, session, request_uri)
-    request = DummyRequest.new(env, parameters, session)
-    DummyController.new(request_uri, request, session)
+    request = DummyRequest.new(env, parameters, DummySession.new(session))
+    DummyController.new(request_uri, request, DummySession.new(session))
   end
 end

--- a/test/unit/exception_handling/exception_info_test.rb
+++ b/test/unit/exception_handling/exception_info_test.rb
@@ -143,6 +143,12 @@ module ExceptionHandling
         @data_callback = ->(data) { data[:custom_section] = "check this out" }
       end
 
+      should "not return a mutable object for the session" do
+        exception_info = ExceptionInfo.new(@exception, @exception_context, @timestamp)
+        exception_info.enhanced_data["session"]["hello"] = "world"
+        assert_nil @controller.session["hello"]
+      end
+
       should "return a hash with generic exception attributes as well as context data" do
         exception_info = ExceptionInfo.new(@exception, @exception_context, @timestamp)
         expected_data = {


### PR DESCRIPTION
no longer pass the mutable shallow dup version of the session to exception context