### PR TITLE
NO_JIRA add context to default_metric_name: special prefix for treat_…

### DIFF
--- a/lib/exception_handling.rb
+++ b/lib/exception_handling.rb
@@ -57,11 +57,14 @@ module ExceptionHandling # never included
       @logger = logger.is_a?(ContextualLogger) ? logger : ContextualLogger.new(logger)
     end
 
-    def default_metric_name(exception_data, exception, _treat_like_warning)
+    def default_metric_name(exception_data, exception, treat_like_warning)
       metric_name = if exception_data['metric_name']
                       exception_data['metric_name']
                     elsif exception.is_a?(ExceptionHandling::Warning)
                       "warning"
+                    elsif treat_like_warning
+                      exception_name = "_#{exception.class.name.split('::').last}" if exception.present?
+                      "unforwarded_exception#{exception_name}"
                     else
                       "exception"
                     end

--- a/test/unit/exception_handling_test.rb
+++ b/test/unit/exception_handling_test.rb
@@ -244,28 +244,46 @@ class ExceptionHandlingTest < ActiveSupport::TestCase
       end
 
       context "default_metric_name" do
-        should "return exception_handling.warning when using log warning" do
-          warning = ExceptionHandling::Warning.new('this is a warning')
-          metric  = ExceptionHandling.default_metric_name({}, warning, false)
-          assert_equal 'exception_handling.warning', metric
+
+        context "when metric_name is present in exception_data" do
+          should "include metric_name in resulting metric name" do
+            exception = StandardError.new('this is an exception')
+            metric    = ExceptionHandling.default_metric_name({ 'metric_name' => 'special_metric' }, exception, true)
+            assert_equal 'exception_handling.special_metric', metric
+          end
         end
 
-        should "return exception_handling.exception when using treat_like_warning" do
-          exception = StandardError.new('this is an exception')
-          metric    = ExceptionHandling.default_metric_name({}, exception, true)
-          assert_equal 'exception_handling.exception', metric
-        end
+        context "when metric_name is not present in exception_data" do
+          should "return exception_handling.warning when using log warning" do
+            warning = ExceptionHandling::Warning.new('this is a warning')
+            metric  = ExceptionHandling.default_metric_name({}, warning, false)
+            assert_equal 'exception_handling.warning', metric
+          end
 
-        should "return exception_handling.exception when using log error" do
-          exception = StandardError.new('this is an exception')
-          metric    = ExceptionHandling.default_metric_name({}, exception, false)
-          assert_equal 'exception_handling.exception', metric
-        end
+          should "return exception_handling.exception when using log error" do
+            exception = StandardError.new('this is an exception')
+            metric    = ExceptionHandling.default_metric_name({}, exception, false)
+            assert_equal 'exception_handling.exception', metric
+          end
 
-        should "return special metric when specified in exception filtering" do
-          exception = StandardError.new('this is an exception')
-          metric    = ExceptionHandling.default_metric_name({ 'metric_name' => 'special_metric' }, exception, true)
-          assert_equal 'exception_handling.special_metric', metric
+          context "when using log error with treat_like_warning" do
+            should "return exception_handling.unforwarded_exception when exception not present" do
+              exception = StandardError.new('this is an exception')
+              metric    = ExceptionHandling.default_metric_name({}, nil, true)
+              assert_equal 'exception_handling.unforwarded_exception', metric
+            end
+
+            should "return exception_handling.unforwarded_exception with exception classname when exception is present" do
+              module SomeModule
+                class SomeException < StandardError
+                end
+              end
+
+              exception = SomeModule::SomeException.new('this is an exception')
+              metric    = ExceptionHandling.default_metric_name({}, exception, true)
+              assert_equal 'exception_handling.unforwarded_exception_SomeException', metric
+            end
+          end
         end
       end
 

--- a/test/unit/exception_handling_test.rb
+++ b/test/unit/exception_handling_test.rb
@@ -268,8 +268,7 @@ class ExceptionHandlingTest < ActiveSupport::TestCase
 
           context "when using log error with treat_like_warning" do
             should "return exception_handling.unforwarded_exception when exception not present" do
-              exception = StandardError.new('this is an exception')
-              metric    = ExceptionHandling.default_metric_name({}, nil, true)
+              metric = ExceptionHandling.default_metric_name({}, nil, true)
               assert_equal 'exception_handling.unforwarded_exception', metric
             end
 


### PR DESCRIPTION
- treat_like_warning exceptions increment the `unforwarded_exceptions` metric rather than `exceptions`. This is because we blew up our alerts on `exceptions` when adding all these new treat_like_warning exceptions.
- `unforwarded_exceptions` will be suffixed with the exception classname when available.