### PR TITLE
handle exceptions in local_variable_filter

### DIFF
--- a/lib/exception_handling/honeybadger_callbacks.rb
+++ b/lib/exception_handling/honeybadger_callbacks.rb
@@ -26,7 +26,7 @@ module ExceptionHandling
                     " @id=#{object.id}"
                   end
 
-        "#<#{object.class.name}#{details} [error '#{ex.class.name} - #{ex.message}' while calling #inspect]>"
+        "#<#{object.class.name}#{details} [error '#{ex.class.name}: #{ex.message}' while calling #inspect]>"
       end
 
       def local_variable_filter(_symbol, object, filter_keys)

--- a/lib/exception_handling/honeybadger_callbacks.rb
+++ b/lib/exception_handling/honeybadger_callbacks.rb
@@ -11,18 +11,31 @@ module ExceptionHandling
 
       private
 
+      def inspect_object(object, filter_keys)
+        inspection_output = object.inspect
+
+        if contains_filter_key?(filter_keys, inspection_output)
+          filtered_object(object)
+        else
+          inspection_output
+        end
+      rescue => ex
+        details = if object.respond_to?(:to_pk)
+                    " @pk=#{object.to_pk}"
+                  elsif object.respond_to?(:id)
+                    " @id=#{object.id}"
+                  end
+
+        "#<#{object.class.name}#{details} [error '#{ex.class.name} - #{ex.message}' while calling #inspect]>"
+      end
+
       def local_variable_filter(_symbol, object, filter_keys)
         case object
         # Honeybadger will filter these data types for us
         when String, Hash, Array, Set, Numeric, TrueClass, FalseClass, NilClass
           object
         else # handle other Ruby objects, intended for POROs
-          inspection_output = object.inspect
-          if contains_filter_key?(filter_keys, inspection_output)
-            filtered_object(object)
-          else
-            inspection_output
-          end
+          inspect_object(object, filter_keys)
         end
       end
 

--- a/test/unit/exception_handling/honeybadger_callbacks_test.rb
+++ b/test/unit/exception_handling/honeybadger_callbacks_test.rb
@@ -36,6 +36,24 @@ module ExceptionHandling
       end
     end
 
+    class TestRaiseOnInspect < TestPoroWithAttribute
+      def inspect
+        raise "some error"
+      end
+    end
+
+    class TestRaiseOnInspectWithId< TestRaiseOnInspect
+      def id
+        123
+      end
+    end
+
+    class TestRaiseOnInspectWithToPk < TestRaiseOnInspect
+      def to_pk
+        "SomeRecord-123"
+      end
+    end
+
     context "register_callbacks" do
       should "store the callbacks in the honeybadger object" do
         HoneybadgerCallbacks.register_callbacks
@@ -64,6 +82,23 @@ module ExceptionHandling
       should "inspect other classes" do
         result = HoneybadgerCallbacks.send(:local_variable_filter, :variable_name, TestPoroWithAttribute.new, ['password'])
         assert_match(/#<ExceptionHandling::HoneybadgerCallbacksTest::TestPoroWithAttribute:.* @test_attribute="test">/, result)
+      end
+
+      context "when inspect raises exceptions" do
+        should "handle exceptions for objects" do
+          result = HoneybadgerCallbacks.send(:local_variable_filter, :variable_name, TestRaiseOnInspect.new, ['password'])
+          assert_equal "#<ExceptionHandling::HoneybadgerCallbacksTest::TestRaiseOnInspect [error 'RuntimeError - some error' while calling #inspect]>", result
+        end
+
+        should "handle exceptions for objects responding to id" do
+          result = HoneybadgerCallbacks.send(:local_variable_filter, :variable_name, TestRaiseOnInspectWithId.new, ['password'])
+          assert_equal "#<ExceptionHandling::HoneybadgerCallbacksTest::TestRaiseOnInspectWithId @id=123 [error 'RuntimeError - some error' while calling #inspect]>", result
+        end
+
+        should "handle exceptions for objects responding to to_pik" do
+          result = HoneybadgerCallbacks.send(:local_variable_filter, :variable_name, TestRaiseOnInspectWithToPk.new, ['password'])
+          assert_equal "#<ExceptionHandling::HoneybadgerCallbacksTest::TestRaiseOnInspectWithToPk @pk=SomeRecord-123 [error 'RuntimeError - some error' while calling #inspect]>", result
+        end
       end
 
       context "not inspect objects that contain filter keys" do

--- a/test/unit/exception_handling/honeybadger_callbacks_test.rb
+++ b/test/unit/exception_handling/honeybadger_callbacks_test.rb
@@ -42,7 +42,7 @@ module ExceptionHandling
       end
     end
 
-    class TestRaiseOnInspectWithId< TestRaiseOnInspect
+    class TestRaiseOnInspectWithId < TestRaiseOnInspect
       def id
         123
       end
@@ -87,17 +87,17 @@ module ExceptionHandling
       context "when inspect raises exceptions" do
         should "handle exceptions for objects" do
           result = HoneybadgerCallbacks.send(:local_variable_filter, :variable_name, TestRaiseOnInspect.new, ['password'])
-          assert_equal "#<ExceptionHandling::HoneybadgerCallbacksTest::TestRaiseOnInspect [error 'RuntimeError - some error' while calling #inspect]>", result
+          assert_equal "#<ExceptionHandling::HoneybadgerCallbacksTest::TestRaiseOnInspect [error 'RuntimeError: some error' while calling #inspect]>", result
         end
 
         should "handle exceptions for objects responding to id" do
           result = HoneybadgerCallbacks.send(:local_variable_filter, :variable_name, TestRaiseOnInspectWithId.new, ['password'])
-          assert_equal "#<ExceptionHandling::HoneybadgerCallbacksTest::TestRaiseOnInspectWithId @id=123 [error 'RuntimeError - some error' while calling #inspect]>", result
+          assert_equal "#<ExceptionHandling::HoneybadgerCallbacksTest::TestRaiseOnInspectWithId @id=123 [error 'RuntimeError: some error' while calling #inspect]>", result
         end
 
         should "handle exceptions for objects responding to to_pik" do
           result = HoneybadgerCallbacks.send(:local_variable_filter, :variable_name, TestRaiseOnInspectWithToPk.new, ['password'])
-          assert_equal "#<ExceptionHandling::HoneybadgerCallbacksTest::TestRaiseOnInspectWithToPk @pk=SomeRecord-123 [error 'RuntimeError - some error' while calling #inspect]>", result
+          assert_equal "#<ExceptionHandling::HoneybadgerCallbacksTest::TestRaiseOnInspectWithToPk @pk=SomeRecord-123 [error 'RuntimeError: some error' while calling #inspect]>", result
         end
       end
 


### PR DESCRIPTION
- exceptions from Honeybadger.local_variable_filter can fly out of Honeybadger.notify
- this can cause send_exception_to_honeybadger to fail.