### PR TITLE
No jira release to rubygems

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,6 @@ gem 'actionmailer',  '>= 4.2.11.1'
 gem 'actionpack',    '>= 4.2.11.1'
 gem 'activesupport', '>= 4.2.11.1'
 gem 'hobo_support',   '2.0.1',      git: 'git@github.com:Invoca/hobosupport',    ref: 'b9086322274b474a2b5bae507c4885e55d4aa050'
-gem 'invoca-utils',                 git: 'git@github.com:Invoca/invoca-utils',   ref: '891b8f7e1af0f6324bf85601046907143122e204'
 
 group :development do
   gem 'pry'

--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,6 @@ gemspec
 gem 'actionmailer',  '>= 4.2.11.1'
 gem 'actionpack',    '>= 4.2.11.1'
 gem 'activesupport', '>= 4.2.11.1'
-gem 'hobo_support',   '2.0.1',      git: 'git@github.com:Invoca/hobosupport',    ref: 'b9086322274b474a2b5bae507c4885e55d4aa050'
 
 group :development do
   gem 'pry'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,12 +1,4 @@
 GIT
-  remote: git@github.com:Invoca/hobosupport
-  revision: b9086322274b474a2b5bae507c4885e55d4aa050
-  ref: b9086322274b474a2b5bae507c4885e55d4aa050
-  specs:
-    hobo_support (2.0.1)
-      rails (~> 4.2.10)
-
-GIT
   remote: git@github.com:Invoca/honeybadger-ruby
   revision: bb5f2b8a86e4147c38a6270d39ad610fab4dd5e6
   ref: bb5f2b8a86e4147c38a6270d39ad610fab4dd5e6
@@ -75,6 +67,8 @@ GEM
     eventmachine (1.2.7)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
+    hobo_support (2.2.6)
+      rails (~> 4.2.6)
     i18n (0.9.5)
       concurrent-ruby (~> 1.0)
     invoca-utils (0.0.5)
@@ -148,7 +142,7 @@ GEM
       actionpack (>= 4.0)
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
-    thor (0.20.3)
+    thor (1.0.1)
     thread_safe (0.3.6)
     tzinfo (1.2.5)
       thread_safe (~> 0.1)
@@ -162,7 +156,6 @@ DEPENDENCIES
   actionpack (>= 4.2.11.1)
   activesupport (>= 4.2.11.1)
   exception_handling!
-  hobo_support (= 2.0.1)!
   honeybadger (= 3.3.1.pre.1)!
   pry
   rake (>= 0.9)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -13,13 +13,6 @@ GIT
   specs:
     honeybadger (3.3.1.pre.1)
 
-GIT
-  remote: git@github.com:Invoca/invoca-utils
-  revision: 891b8f7e1af0f6324bf85601046907143122e204
-  ref: 891b8f7e1af0f6324bf85601046907143122e204
-  specs:
-    invoca-utils (0.0.3)
-
 PATH
   remote: .
   specs:
@@ -84,6 +77,7 @@ GEM
       activesupport (>= 4.2.0)
     i18n (0.9.5)
       concurrent-ruby (~> 1.0)
+    invoca-utils (0.0.5)
     jaro_winkler (1.5.3)
     json (2.2.0)
     loofah (2.2.3)
@@ -170,7 +164,6 @@ DEPENDENCIES
   exception_handling!
   hobo_support (= 2.0.1)!
   honeybadger (= 3.3.1.pre.1)!
-  invoca-utils!
   pry
   rake (>= 0.9)
   rr

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,7 +8,7 @@ GIT
 PATH
   remote: .
   specs:
-    exception_handling (2.2.4)
+    exception_handling (2.3.0.pre.1)
       actionmailer (~> 4.2)
       actionpack (~> 4.2)
       activesupport (~> 4.2)
@@ -73,7 +73,7 @@ GEM
       concurrent-ruby (~> 1.0)
     invoca-utils (0.0.5)
     jaro_winkler (1.5.3)
-    json (2.2.0)
+    json (2.3.0)
     loofah (2.2.3)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)

--- a/lib/exception_handling/version.rb
+++ b/lib/exception_handling/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ExceptionHandling
-  VERSION = '2.2.4'
+  VERSION = '2.3.0.pre.1'
 end


### PR DESCRIPTION
Release the current code to Rubygems under a new version:
https://rubygems.org/gems/exception_handling/versions/2.3.0.pre.1

It's been released as a pre-release version. Once this is merged to master, I'll follow up with a full release of version 2.3.0