### PR TITLE
TECH-4176: drop unused controller arg and double splat

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,7 +8,7 @@ GIT
 PATH
   remote: .
   specs:
-    exception_handling (2.3.0)
+    exception_handling (2.4.0.pre.1)
       actionmailer (~> 4.2)
       actionpack (~> 4.2)
       activesupport (~> 4.2)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,7 +8,7 @@ GIT
 PATH
   remote: .
   specs:
-    exception_handling (2.4.0.pre.1)
+    exception_handling (2.4.0.pre.2)
       actionmailer (~> 4.2)
       actionpack (~> 4.2)
       activesupport (~> 4.2)
@@ -164,4 +164,4 @@ DEPENDENCIES
   shoulda (> 3.1.1)
 
 BUNDLED WITH
-   1.17.2
+   1.17.3

--- a/exception_handling.gemspec
+++ b/exception_handling.gemspec
@@ -3,13 +3,13 @@
 require File.expand_path('lib/exception_handling/version', __dir__)
 
 Gem::Specification.new do |spec|
-  spec.authors       = ["Colin Kelley"]
-  spec.email         = ["colindkelley@gmail.com"]
+  spec.authors       = ["Invoca"]
+  spec.email         = ["development@invoca.com"]
   spec.description   = 'Exception handling logger/emailer'
   spec.summary       = "Invoca's exception handling logger/emailer layer, based on exception_notifier. Works with Rails or EventMachine or EventMachine+Synchrony."
   spec.homepage      = "https://github.com/Invoca/exception_handling"
 
-  spec.files         = `git ls-files`.split($OUTPUT_RECORD_SEPARATOR)
+  spec.files         = `git ls-files`.split("\n")
   spec.executables   = spec.files.grep(%r{^bin/}).map { |f| File.basename(f) }
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/.*\.rb})
   spec.name          = "exception_handling"

--- a/exception_handling.gemspec
+++ b/exception_handling.gemspec
@@ -15,6 +15,10 @@ Gem::Specification.new do |spec|
   spec.name          = "exception_handling"
   spec.require_paths = ["lib"]
   spec.version       = ExceptionHandling::VERSION
+  spec.metadata    = {
+    "source_code_uri"   => "https://github.com/Invoca/exception_handling",
+    "allowed_push_host" => "https://rubygems.org"
+  }
 
   spec.add_dependency 'actionmailer',  '~> 4.2'
   spec.add_dependency 'actionpack',    '~> 4.2'

--- a/lib/exception_handling.rb
+++ b/lib/exception_handling.rb
@@ -177,13 +177,16 @@ module ExceptionHandling # never included
     #   Called directly by our code, usually from rescue blocks.
     #   Writes to log file and may send to honeybadger
     #
+    # TODO: the **log_context means we can never have context named treat_like_warning. In general, keyword args will be conflated with log_context.
+    # Ideally we'd separate to log_context from the other keywords so they don't interfere in any way. Or have no keyword args.
+    #
     # Functional Test Operation:
     #   Calls into handle_stub_log_error and returns. no log file. no honeybadger
     #
-    def log_error(exception_or_string, exception_context = '', treat_like_warning: false, **log_context, &data_callback)
+    def log_error(exception_or_string, exception_context = '', controller = nil, treat_like_warning: false, **log_context, &data_callback)
       ex = make_exception(exception_or_string)
       timestamp = set_log_error_timestamp
-      exception_info = ExceptionInfo.new(ex, exception_context, timestamp, current_controller, data_callback)
+      exception_info = ExceptionInfo.new(ex, exception_context, timestamp, controller || current_controller, data_callback)
 
       if stub_handler
         stub_handler.handle_stub_log_error(exception_info.data)

--- a/lib/exception_handling/version.rb
+++ b/lib/exception_handling/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ExceptionHandling
-  VERSION = '2.4.0.pre.1'
+  VERSION = '2.4.0.pre.2'
 end

--- a/lib/exception_handling/version.rb
+++ b/lib/exception_handling/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ExceptionHandling
-  VERSION = '2.3.0'
+  VERSION = '2.4.0.pre.1'
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -27,15 +27,15 @@ class LoggerStub
     clear
   end
 
-  def info(message, **log_context)
+  def info(message, log_context = {})
     logged << { message: message, context: log_context }
   end
 
-  def warn(message, **log_context)
+  def warn(message, log_context = {})
     logged << { message: message, context: log_context }
   end
 
-  def fatal(message, **log_context)
+  def fatal(message, log_context = {})
     logged << { message: message, context: log_context }
   end
 

--- a/test/unit/exception_handling_test.rb
+++ b/test/unit/exception_handling_test.rb
@@ -110,14 +110,7 @@ class ExceptionHandlingTest < ActiveSupport::TestCase
     end
 
     context "#log_error" do
-      should "take in additional keyword args as logging context and pass them to the logger (using preferrred log_context:)" do
-        ExceptionHandling.log_error('This is an Error', 'This is the prefix context', service_name: 'exception_handling')
-        assert_match(/This is an Error/, logged_excluding_reload_filter.last[:message])
-        assert_not_empty logged_excluding_reload_filter.last[:context]
-        assert_equal({ service_name: 'exception_handling' }, logged_excluding_reload_filter.last[:context])
-      end
-
-      should "take in additional keyword args as logging context and pass them to the logger (using **)" do
+      should "take in additional logging context hash and pass it to the logger" do
         ExceptionHandling.log_error('This is an Error', 'This is the prefix context', service_name: 'exception_handling')
         assert_match(/This is an Error/, logged_excluding_reload_filter.last[:message])
         assert_not_empty logged_excluding_reload_filter.last[:context]

--- a/test/unit/exception_handling_test.rb
+++ b/test/unit/exception_handling_test.rb
@@ -543,10 +543,6 @@ class ExceptionHandlingTest < ActiveSupport::TestCase
         end
 
         context "with Honeybadger defined" do
-          teardown do
-            ExceptionHandling.current_controller = nil
-          end
-
           should "not send_exception_to_honeybadger when log_warning is executed" do
             dont_allow(ExceptionHandling).send_exception_to_honeybadger
             ExceptionHandling.log_warning("This should not go to honeybadger")
@@ -585,7 +581,7 @@ class ExceptionHandlingTest < ActiveSupport::TestCase
             parameters = { advertiser_id: 435, controller: "some_controller" }
             session = { username: "jsmith" }
             request_uri = "host/path"
-            ExceptionHandling.current_controller = create_dummy_controller(env, parameters, session, request_uri)
+            controller = create_dummy_controller(env, parameters, session, request_uri)
             stub(ExceptionHandling).server_name { "invoca_fe98" }
 
             exception = StandardError.new("Some Exception")
@@ -599,7 +595,7 @@ class ExceptionHandlingTest < ActiveSupport::TestCase
             mock(Honeybadger).notify.with_any_args do |data|
               honeybadger_data = data
             end
-            ExceptionHandling.log_error(exception, exception_context) do |data|
+            ExceptionHandling.log_error(exception, exception_context, controller) do |data|
               data[:scm_revision] = "5b24eac37aaa91f5784901e9aabcead36fd9df82"
               data[:user_details] = { username: "jsmith" }
               data[:event_response] = "Event successfully received"

--- a/test/unit/exception_handling_test.rb
+++ b/test/unit/exception_handling_test.rb
@@ -424,8 +424,8 @@ class ExceptionHandlingTest < ActiveSupport::TestCase
 
           ExceptionHandling.ensure_escalation("ensure context") { raise ArgumentError, "first_test_exception" }
 
-          assert_match /ArgumentError.*first_test_exception/, log_fatals[0].first
-          assert_match /safe_email_deliver.*Delivery Error/, log_fatals[1].first
+          assert_match(/ArgumentError.*first_test_exception/, log_fatals[0].first)
+          assert_match(/safe_email_deliver.*Delivery Error/, log_fatals[1].first)
 
           assert_equal 2, log_fatals.size, log_fatals.inspect
 


### PR DESCRIPTION
- Removes unused `controller` argument from `log_error`.
- Removes `**` when we are just passing a log_context hash (not keyword args).