### PR TITLE
TECH-4193: deprecate ContextualLogging.new overload

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 .rubocop-http*
 test/reports/*
 gemfiles/*.lock
+pkg/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ Inspired by [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 Note: this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.4.3] - Unreleased
+### Deprecated
+- In `ExceptionHandling.logger=`, implicit `logger.extend ContextualLogger::LoggerMixin` is now deprecated.
+  This will be removed in version 3.0 and an `ArgumentError` will be raised if the logger
+  doesn't have that mixin. Instead of this implicit behavior, you should explicitly either `extend`
+  your logger instance or `include` that mixin into your `Logger` class. 
+
 ## [2.4.2] - 2020-05-11
 ### Added
 - Added support for rails 5 and 6.
@@ -17,5 +24,6 @@ Note: this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0
 ### Changed
 - No longer depends on hobo_support. Uses invoca-utils 0.3 instead.
 
+[2.4.3]: https://github.com/Invoca/exception_handling/compare/v2.4.2...v2.4.3
 [2.4.2]: https://github.com/Invoca/exception_handling/compare/v2.4.1...v2.4.2
 [2.4.1]: https://github.com/Invoca/exception_handling/compare/v2.4.0...v2.4.1

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,7 +8,7 @@ GIT
 PATH
   remote: .
   specs:
-    exception_handling (2.4.3.pre.1)
+    exception_handling (2.4.3.pre.2)
       actionmailer (>= 4.2, < 7.0)
       actionpack (>= 4.2, < 7.0)
       activesupport (>= 4.2, < 7.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,7 +8,7 @@ GIT
 PATH
   remote: .
   specs:
-    exception_handling (2.4.2)
+    exception_handling (2.4.3.pre.1)
       actionmailer (>= 4.2, < 7.0)
       actionpack (>= 4.2, < 7.0)
       activesupport (>= 4.2, < 7.0)

--- a/lib/exception_handling.rb
+++ b/lib/exception_handling.rb
@@ -60,7 +60,7 @@ module ExceptionHandling # never included
       @logger = if logger.is_a?(ContextualLogger::LoggerMixin)
                   logger
                 else
-                  Deprecation3_0.deprecation_warning('implicit extend with ContextualLogger::LoggerMixin', 'extend your logger instance or include your into your logger class first')
+                  Deprecation3_0.deprecation_warning('implicit extend with ContextualLogger::LoggerMixin', 'extend your logger instance or include into your logger class first')
                   logger.extend(ContextualLogger::LoggerMixin)
                 end
     end

--- a/lib/exception_handling.rb
+++ b/lib/exception_handling.rb
@@ -54,8 +54,15 @@ module ExceptionHandling # never included
       @logger or raise ArgumentError, "You must assign a value to #{name}.logger"
     end
 
+    Deprecation3_0 = ActiveSupport::Deprecation.new('3.0', 'exception_handling')
+
     def logger=(logger)
-      @logger = logger.is_a?(ContextualLogger) ? logger : ContextualLogger.new(logger)
+      @logger = if logger.is_a?(ContextualLogger::LoggerMixin)
+                  logger
+                else
+                  Deprecation3_0.deprecation_warning('implicit extend with ContextualLogger::LoggerMixin', 'extend your logger instance or include your into your logger class first')
+                  logger.extend(ContextualLogger::LoggerMixin)
+                end
     end
 
     def default_metric_name(exception_data, exception, treat_like_warning)

--- a/lib/exception_handling/version.rb
+++ b/lib/exception_handling/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ExceptionHandling
-  VERSION = '2.4.3.pre.1'
+  VERSION = '2.4.3.pre.2'
 end

--- a/lib/exception_handling/version.rb
+++ b/lib/exception_handling/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ExceptionHandling
-  VERSION = '2.4.2'
+  VERSION = '2.4.3.pre.1'
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -23,10 +23,13 @@ require 'exception_handling/testing'
 ActiveSupport::TestCase.test_order = :sorted
 
 class LoggerStub
-  include ContextualLogger
-  attr_accessor :logged
+  include ContextualLogger::LoggerMixin
+  attr_accessor :logged, :level
 
   def initialize
+    @level = Logger::Severity::DEBUG
+    @progname = nil
+    @logdev = nil
     clear
   end
 

--- a/test/unit/exception_handling_test.rb
+++ b/test/unit/exception_handling_test.rb
@@ -8,6 +8,10 @@ class ExceptionHandlingTest < ActiveSupport::TestCase
   include ControllerHelpers
   include ExceptionHelpers
 
+  setup do
+    @fail_count = 0
+  end
+
   def dont_stub_log_error
     true
   end
@@ -192,7 +196,6 @@ class ExceptionHandlingTest < ActiveSupport::TestCase
       end
 
       should "support a log_error hook, and pass exception_data, treat_like_warning, and logged_to_honeybadger to it" do
-        @fail_count = 0
         @honeybadger_status = nil
         ExceptionHandling.post_log_error_hook = method(:log_error_callback_config)
 
@@ -209,7 +212,6 @@ class ExceptionHandlingTest < ActiveSupport::TestCase
       end
 
       should "plumb treat_like_warning and logged_to_honeybadger to log error hook" do
-        @fail_count = 0
         @honeybadger_status = nil
         ExceptionHandling.post_log_error_hook = method(:log_error_callback_config)
         ExceptionHandling.log_error(StandardError.new("Some Exception"), "mooo", treat_like_warning: true)
@@ -682,7 +684,6 @@ class ExceptionHandlingTest < ActiveSupport::TestCase
             end
 
             should "not send notification to honeybadger when exception description has the flag turned off and call log error callback with logged_to_honeybadger set to nil" do
-              @fail_count = 0
               @honeybadger_status = nil
               ExceptionHandling.post_log_error_hook = method(:log_error_callback_config)
               filter_list = {
@@ -701,7 +702,6 @@ class ExceptionHandlingTest < ActiveSupport::TestCase
             end
 
             should "call log error callback with logged_to_honeybadger set to false if an error occurs while attempting to notify honeybadger" do
-              @fail_count = 0
               @honeybadger_status = nil
               ExceptionHandling.post_log_error_hook = method(:log_error_callback_config)
               mock(Honeybadger).notify.with_any_args { raise "Honeybadger Notification Failure" }
@@ -710,7 +710,6 @@ class ExceptionHandlingTest < ActiveSupport::TestCase
             end
 
             should "call log error callback with logged_to_honeybadger set to false on unsuccessful honeybadger notification" do
-              @fail_count = 0
               @honeybadger_status = nil
               ExceptionHandling.post_log_error_hook = method(:log_error_callback_config)
               mock(Honeybadger).notify.with_any_args { false }
@@ -719,7 +718,6 @@ class ExceptionHandlingTest < ActiveSupport::TestCase
             end
 
             should "call log error callback with logged_to_honeybadger set to true on successful honeybadger notification" do
-              @fail_count = 0
               @honeybadger_status = nil
               ExceptionHandling.post_log_error_hook = method(:log_error_callback_config)
               mock(Honeybadger).notify.with_any_args { '06220c5a-b471-41e5-baeb-de247da45a56' }


### PR DESCRIPTION
## [2.4.3] - Unreleased
### Deprecated
- In `ExceptionHandling.logger=`, implicit `logger.extend ContextualLogger::LoggerMixin` is now deprecated.
  This will be removed in version 3.0 and an `ArgumentError` will be raised if the logger
  doesn't have that mixin. Instead of this implicit behavior, you should explicitly either `extend`
  your logger instance or `include` that mixin into your `Logger` class. 