### PR TITLE
TECH-4213: expose log context to honeybadger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Inspired by [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 Note: this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [2.5.0] - Unreleased
+## [2.5.0] - 2020-08-19
 ### Added
 - The `**log_context` passed to `log_error`/`log_warning`/`log_info` is now
   passed into `Honeybadger.notify()`, in `context: { log_context: ... }`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ Inspired by [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 Note: this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.5.0] - Unreleased
+### Added
+- The `**log_context` passed to `log_error`/`log_warning`/`log_info` is now
+  passed into `Honeybadger.notify()`, in `context: { log_context: ... }`.
+
 ## [2.4.3] - 2020-05-14
 ### Deprecated
 - In `ExceptionHandling.logger=`, implicit `logger.extend ContextualLogger::LoggerMixin` is now deprecated.
@@ -24,6 +29,7 @@ Note: this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0
 ### Changed
 - No longer depends on hobo_support. Uses invoca-utils 0.3 instead.
 
+[2.5.0]: https://github.com/Invoca/exception_handling/compare/v2.4.3...v2.5.0
 [2.4.3]: https://github.com/Invoca/exception_handling/compare/v2.4.2...v2.4.3
 [2.4.2]: https://github.com/Invoca/exception_handling/compare/v2.4.1...v2.4.2
 [2.4.1]: https://github.com/Invoca/exception_handling/compare/v2.4.0...v2.4.1

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,7 +8,7 @@ GIT
 PATH
   remote: .
   specs:
-    exception_handling (2.4.4)
+    exception_handling (2.5.0.pre.1)
       actionmailer (>= 4.2, < 7.0)
       actionpack (>= 4.2, < 7.0)
       activesupport (>= 4.2, < 7.0)
@@ -55,7 +55,7 @@ GEM
     builder (3.2.3)
     coderay (1.1.2)
     concurrent-ruby (1.1.5)
-    contextual_logger (0.8.0)
+    contextual_logger (0.9.1)
       activesupport
       json
     crass (1.0.6)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,7 +8,7 @@ GIT
 PATH
   remote: .
   specs:
-    exception_handling (2.4.3)
+    exception_handling (2.5.0.pre.1)
       actionmailer (>= 4.2, < 7.0)
       actionpack (>= 4.2, < 7.0)
       activesupport (>= 4.2, < 7.0)
@@ -55,7 +55,7 @@ GEM
     builder (3.2.3)
     coderay (1.1.2)
     concurrent-ruby (1.1.5)
-    contextual_logger (0.7.0)
+    contextual_logger (0.8.0)
       activesupport
       json
     crass (1.0.6)
@@ -65,10 +65,10 @@ GEM
       activesupport (>= 4.2.0)
     i18n (0.9.5)
       concurrent-ruby (~> 1.0)
-    invoca-utils (0.3.0)
+    invoca-utils (0.4.1)
     jaro_winkler (1.5.3)
-    json (2.3.0)
-    loofah (2.5.0)
+    json (2.3.1)
+    loofah (2.6.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
     mail (2.7.1)
@@ -82,7 +82,7 @@ GEM
       builder
       minitest (>= 5.0)
       ruby-progressbar
-    nokogiri (1.10.9)
+    nokogiri (1.10.10)
       mini_portile2 (~> 2.4.0)
     parallel (1.17.0)
     parser (2.6.3.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,7 +8,7 @@ GIT
 PATH
   remote: .
   specs:
-    exception_handling (2.5.0.pre.2)
+    exception_handling (2.5.0)
       actionmailer (>= 4.2, < 7.0)
       actionpack (>= 4.2, < 7.0)
       activesupport (>= 4.2, < 7.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,7 +8,7 @@ GIT
 PATH
   remote: .
   specs:
-    exception_handling (2.5.0.pre.1)
+    exception_handling (2.5.0.pre.2)
       actionmailer (>= 4.2, < 7.0)
       actionpack (>= 4.2, < 7.0)
       activesupport (>= 4.2, < 7.0)

--- a/Rakefile
+++ b/Rakefile
@@ -4,6 +4,8 @@
 require "bundler/gem_tasks"
 require 'rake/testtask'
 
+require_relative 'test/rake_test_warning_false'
+
 task default: :test
 
 Rake::TestTask.new do |t|

--- a/lib/exception_handling.rb
+++ b/lib/exception_handling.rb
@@ -195,7 +195,7 @@ module ExceptionHandling # never included
       timestamp = set_log_error_timestamp
       exception_info = ExceptionInfo.new(ex, exception_context, timestamp,
                                          controller: controller || current_controller, data_callback: data_callback,
-                                         log_context: logger.current_context_for_thread.deep_merge(log_context))
+                                         log_context: log_context)
 
       if stub_handler
         stub_handler.handle_stub_log_error(exception_info.data)

--- a/lib/exception_handling.rb
+++ b/lib/exception_handling.rb
@@ -195,7 +195,7 @@ module ExceptionHandling # never included
       timestamp = set_log_error_timestamp
       exception_info = ExceptionInfo.new(ex, exception_context, timestamp,
                                          controller: controller || current_controller, data_callback: data_callback,
-                                         log_context: log_context)
+                                         log_context: logger.current_context_for_thread.deep_merge(log_context))
 
       if stub_handler
         stub_handler.handle_stub_log_error(exception_info.data)

--- a/lib/exception_handling.rb
+++ b/lib/exception_handling.rb
@@ -162,7 +162,7 @@ module ExceptionHandling # never included
     #
     def log_error_rack(exception, env, _rack_filter)
       timestamp = set_log_error_timestamp
-      exception_info = ExceptionInfo.new(exception, env, timestamp)
+      exception_info = ExceptionInfo.new(exception, exception_context: env, timestamp: timestamp)
 
       if stub_handler
         stub_handler.handle_stub_log_error(exception_info.data)
@@ -193,7 +193,7 @@ module ExceptionHandling # never included
     def log_error(exception_or_string, exception_context = '', controller = nil, treat_like_warning: false, **log_context, &data_callback)
       ex = make_exception(exception_or_string)
       timestamp = set_log_error_timestamp
-      exception_info = ExceptionInfo.new(ex, exception_context, timestamp, controller || current_controller, data_callback)
+      exception_info = ExceptionInfo.new(ex, exception_context: exception_context, timestamp: timestamp, controller: controller || current_controller, data_callback: data_callback)
 
       if stub_handler
         stub_handler.handle_stub_log_error(exception_info.data)
@@ -420,7 +420,7 @@ module ExceptionHandling # never included
     end
 
     def escalate(email_subject, ex, timestamp, custom_recipients = nil)
-      exception_info = ExceptionInfo.new(ex, nil, timestamp)
+      exception_info = ExceptionInfo.new(ex, timestamp: timestamp)
       deliver(ExceptionHandling::Mailer.escalation_notification(email_subject, exception_info.data, custom_recipients))
     end
 

--- a/lib/exception_handling.rb
+++ b/lib/exception_handling.rb
@@ -162,7 +162,7 @@ module ExceptionHandling # never included
     #
     def log_error_rack(exception, env, _rack_filter)
       timestamp = set_log_error_timestamp
-      exception_info = ExceptionInfo.new(exception, exception_context: env, timestamp: timestamp)
+      exception_info = ExceptionInfo.new(exception, env, timestamp)
 
       if stub_handler
         stub_handler.handle_stub_log_error(exception_info.data)
@@ -193,7 +193,9 @@ module ExceptionHandling # never included
     def log_error(exception_or_string, exception_context = '', controller = nil, treat_like_warning: false, **log_context, &data_callback)
       ex = make_exception(exception_or_string)
       timestamp = set_log_error_timestamp
-      exception_info = ExceptionInfo.new(ex, exception_context: exception_context, timestamp: timestamp, controller: controller || current_controller, data_callback: data_callback)
+      exception_info = ExceptionInfo.new(ex, exception_context, timestamp,
+                                         controller: controller || current_controller, data_callback: data_callback,
+                                         log_context: log_context)
 
       if stub_handler
         stub_handler.handle_stub_log_error(exception_info.data)
@@ -420,7 +422,7 @@ module ExceptionHandling # never included
     end
 
     def escalate(email_subject, ex, timestamp, custom_recipients = nil)
-      exception_info = ExceptionInfo.new(ex, timestamp: timestamp)
+      exception_info = ExceptionInfo.new(ex, nil, timestamp)
       deliver(ExceptionHandling::Mailer.escalation_notification(email_subject, exception_info.data, custom_recipients))
     end
 

--- a/lib/exception_handling/exception_info.rb
+++ b/lib/exception_handling/exception_info.rb
@@ -51,12 +51,13 @@ module ExceptionHandling
 
     attr_reader :exception, :controller, :exception_context, :timestamp
 
-    def initialize(exception, exception_context: nil, timestamp:, controller: nil, data_callback: nil)
+    def initialize(exception, exception_context, timestamp, controller: nil, data_callback: nil, log_context: nil)
       @exception = exception
       @exception_context = exception_context
       @timestamp = timestamp
       @controller = controller || controller_from_context(exception_context)
       @data_callback = data_callback
+      @log_context = log_context
     end
 
     def data
@@ -268,6 +269,7 @@ module ExceptionHandling
       data = enhanced_data.dup
       data[:server] = ExceptionHandling.server_name
       data[:exception_context] = deep_clean_hash(@exception_context) if @exception_context.present?
+      data[:log_context] = @log_context
       unstringify_sections(data)
       context_data = HONEYBADGER_CONTEXT_SECTIONS.reduce({}) do |context, section|
         if data[section].present?

--- a/lib/exception_handling/exception_info.rb
+++ b/lib/exception_handling/exception_info.rb
@@ -3,7 +3,7 @@
 module ExceptionHandling
   class ExceptionInfo
 
-    ENVIRONMENT_WHITELIST = [
+    ENVIRONMENT_ALLOWLIST = [
       /^HTTP_/,
       /^QUERY_/,
       /^REQUEST_/,
@@ -178,7 +178,7 @@ module ExceptionHandling
 
     def clean_environment(env)
       Hash[ env.map do |k, v|
-        [k, v] if !"#{k}: #{v}".in?(ENVIRONMENT_OMIT) && ENVIRONMENT_WHITELIST.any? { |regex| k =~ regex }
+        [k, v] if !"#{k}: #{v}".in?(ENVIRONMENT_OMIT) && ENVIRONMENT_ALLOWLIST.any? { |regex| k =~ regex }
       end.compact ]
     end
 

--- a/lib/exception_handling/exception_info.rb
+++ b/lib/exception_handling/exception_info.rb
@@ -46,11 +46,12 @@ module ExceptionHandling
     EOS
 
     SECTIONS = [:request, :session, :environment, :backtrace, :event_response].freeze
-    HONEYBADGER_CONTEXT_SECTIONS = [:timestamp, :error_class, :exception_context, :server, :scm_revision, :notes, :user_details, :request, :session, :environment, :backtrace, :event_response].freeze
+    HONEYBADGER_CONTEXT_SECTIONS = [:timestamp, :error_class, :exception_context, :server, :scm_revision, :notes,
+                                    :user_details, :request, :session, :environment, :backtrace, :event_response, :log_context].freeze
 
     attr_reader :exception, :controller, :exception_context, :timestamp
 
-    def initialize(exception, exception_context, timestamp, controller = nil, data_callback = nil)
+    def initialize(exception, exception_context: nil, timestamp:, controller: nil, data_callback: nil)
       @exception = exception
       @exception_context = exception_context
       @timestamp = timestamp

--- a/lib/exception_handling/version.rb
+++ b/lib/exception_handling/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ExceptionHandling
-  VERSION = '2.4.3'
+  VERSION = '2.5.0.pre.1'
 end

--- a/lib/exception_handling/version.rb
+++ b/lib/exception_handling/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ExceptionHandling
-  VERSION = '2.5.0.pre.1'
+  VERSION = '2.5.0.pre.2'
 end

--- a/lib/exception_handling/version.rb
+++ b/lib/exception_handling/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ExceptionHandling
-  VERSION = '2.5.0.pre.2'
+  VERSION = '2.5.0'
 end

--- a/test/unit/exception_handling/honeybadger_callbacks_test.rb
+++ b/test/unit/exception_handling/honeybadger_callbacks_test.rb
@@ -95,7 +95,7 @@ module ExceptionHandling
           assert_equal "#<ExceptionHandling::HoneybadgerCallbacksTest::TestRaiseOnInspectWithId @id=123 [error 'RuntimeError: some error' while calling #inspect]>", result
         end
 
-        should "handle exceptions for objects responding to to_pik" do
+        should "handle exceptions for objects responding to to_pk" do
           result = HoneybadgerCallbacks.send(:local_variable_filter, :variable_name, TestRaiseOnInspectWithToPk.new, ['password'])
           assert_equal "#<ExceptionHandling::HoneybadgerCallbacksTest::TestRaiseOnInspectWithToPk @pk=SomeRecord-123 [error 'RuntimeError: some error' while calling #inspect]>", result
         end

--- a/test/unit/exception_handling_test.rb
+++ b/test/unit/exception_handling_test.rb
@@ -644,7 +644,8 @@ class ExceptionHandlingTest < ActiveSupport::TestCase
               mock(Honeybadger).notify.with_any_args do |data|
                 honeybadger_data = data
               end
-              log_context = { log_source: "gem/listen", cuid: "AA12BC34DE" }
+              ExceptionHandling.logger.global_context = { service_name: "rails", region: "AWS-us-east-1" }
+              log_context = { log_source: "gem/listen", service_name: "bin/console" }
               ExceptionHandling.log_error(@exception, @exception_context, @controller, **log_context) do |data|
                 data[:scm_revision] = "5b24eac37aaa91f5784901e9aabcead36fd9df82"
                 data[:user_details] = { username: "jsmith" }
@@ -682,7 +683,7 @@ class ExceptionHandlingTest < ActiveSupport::TestCase
                     "test/unit/exception_handling_test.rb:455:in `block (4 levels) in <class:ExceptionHandlingTest>'"
                   ],
                   event_response: "Event successfully received",
-                  log_context: { "log_source" => "gem/listen", "cuid" => "AA12BC34DE" }
+                  log_context: { "service_name" => "bin/console", "region" => "AWS-us-east-1", "log_source" => "gem/listen" }
                 }
               }
               assert_equal_with_diff expected_data, honeybadger_data
@@ -693,7 +694,8 @@ class ExceptionHandlingTest < ActiveSupport::TestCase
               mock(Honeybadger).notify.with_any_args do |data|
                 honeybadger_data = data
               end
-              log_context = { }
+              ExceptionHandling.logger.global_context = {}
+              log_context = {}
               ExceptionHandling.log_error(@exception, @exception_context, @controller, **log_context) do |data|
                 data[:scm_revision] = "5b24eac37aaa91f5784901e9aabcead36fd9df82"
                 data[:user_details] = { username: "jsmith" }

--- a/test/unit/exception_handling_test.rb
+++ b/test/unit/exception_handling_test.rb
@@ -636,7 +636,8 @@ class ExceptionHandlingTest < ActiveSupport::TestCase
             mock(Honeybadger).notify.with_any_args do |data|
               honeybadger_data = data
             end
-            ExceptionHandling.log_error(exception, exception_context, controller) do |data|
+            log_context = { log_source: "gem/listen", cuid: "AA12BC34DE" }
+            ExceptionHandling.log_error(exception, exception_context, controller, **log_context) do |data|
               data[:scm_revision] = "5b24eac37aaa91f5784901e9aabcead36fd9df82"
               data[:user_details] = { username: "jsmith" }
               data[:event_response] = "Event successfully received"
@@ -672,7 +673,8 @@ class ExceptionHandlingTest < ActiveSupport::TestCase
                   "test/unit/exception_handling_test.rb:847:in `exception_1'",
                   "test/unit/exception_handling_test.rb:455:in `block (4 levels) in <class:ExceptionHandlingTest>'"
                 ],
-                event_response: "Event successfully received"
+                event_response: "Event successfully received",
+                log_context: { "log_source" => "gem/listen", "cuid" => "AA12BC34DE" }
               }
             }
             assert_equal_with_diff expected_data, honeybadger_data

--- a/test/unit/exception_handling_test.rb
+++ b/test/unit/exception_handling_test.rb
@@ -621,68 +621,120 @@ class ExceptionHandlingTest < ActiveSupport::TestCase
             ExceptionHandling.log_error(exception_with_nil_message)
           end
 
-          should "send error details and relevant context data to Honeybadger" do
-            Time.now_override = Time.now
-            env = { server: "fe98" }
-            parameters = { advertiser_id: 435, controller: "some_controller" }
-            session = { username: "jsmith" }
-            request_uri = "host/path"
-            controller = create_dummy_controller(env, parameters, session, request_uri)
-            stub(ExceptionHandling).server_name { "invoca_fe98" }
+          context "with stubbed values" do
+            setup do
+              Time.now_override = Time.now
+              @env = { server: "fe98" }
+              @parameters = { advertiser_id: 435, controller: "some_controller" }
+              @session = { username: "jsmith" }
+              @request_uri = "host/path"
+              @controller = create_dummy_controller(@env, @parameters, @session, @request_uri)
+              stub(ExceptionHandling).server_name { "invoca_fe98" }
 
-            exception = StandardError.new("Some Exception")
-            exception.set_backtrace([
-                                      "test/unit/exception_handling_test.rb:847:in `exception_1'",
-                                      "test/unit/exception_handling_test.rb:455:in `block (4 levels) in <class:ExceptionHandlingTest>'"
-                                    ])
-            exception_context = { "SERVER_NAME" => "exceptional.com" }
-
-            honeybadger_data = nil
-            mock(Honeybadger).notify.with_any_args do |data|
-              honeybadger_data = data
-            end
-            log_context = { log_source: "gem/listen", cuid: "AA12BC34DE" }
-            ExceptionHandling.log_error(exception, exception_context, controller, **log_context) do |data|
-              data[:scm_revision] = "5b24eac37aaa91f5784901e9aabcead36fd9df82"
-              data[:user_details] = { username: "jsmith" }
-              data[:event_response] = "Event successfully received"
-              data[:other_section] = "This should not be included in the response"
+              @exception = StandardError.new("Some Exception")
+              @exception.set_backtrace([
+                                         "test/unit/exception_handling_test.rb:847:in `exception_1'",
+                                         "test/unit/exception_handling_test.rb:455:in `block (4 levels) in <class:ExceptionHandlingTest>'"
+                                       ])
+              @exception_context = { "SERVER_NAME" => "exceptional.com" }
             end
 
-            expected_data = {
-              error_class: :"Test Exception",
-              error_message: "Some Exception",
-              controller: "some_controller",
-              exception: exception,
-              context: {
-                timestamp: Time.now.to_i,
-                error_class: "StandardError",
-                server: "invoca_fe98",
-                exception_context: { "SERVER_NAME" => "exceptional.com" },
-                scm_revision: "5b24eac37aaa91f5784901e9aabcead36fd9df82",
-                notes: "this is used by a test",
-                user_details: { "username" => "jsmith" },
-                request: {
-                  "params" => { "advertiser_id" => 435, "controller" => "some_controller" },
-                  "rails_root" => "Rails.root not defined. Is this a test environment?",
-                  "url" => "host/path"
-                },
-                session: {
-                  "key" => nil,
-                  "data" => { "username" => "jsmith" }
-                },
-                environment: {
-                  "SERVER_NAME" => "exceptional.com"
-                },
-                backtrace: [
-                  "test/unit/exception_handling_test.rb:847:in `exception_1'",
-                  "test/unit/exception_handling_test.rb:455:in `block (4 levels) in <class:ExceptionHandlingTest>'"
-                ],
-                event_response: "Event successfully received",
-                log_context: { "log_source" => "gem/listen", "cuid" => "AA12BC34DE" }
+            should "send error details and relevant context data to Honeybadger with log_context" do
+              honeybadger_data = nil
+              mock(Honeybadger).notify.with_any_args do |data|
+                honeybadger_data = data
+              end
+              log_context = { log_source: "gem/listen", cuid: "AA12BC34DE" }
+              ExceptionHandling.log_error(@exception, @exception_context, @controller, **log_context) do |data|
+                data[:scm_revision] = "5b24eac37aaa91f5784901e9aabcead36fd9df82"
+                data[:user_details] = { username: "jsmith" }
+                data[:event_response] = "Event successfully received"
+                data[:other_section] = "This should not be included in the response"
+              end
+
+              expected_data = {
+                error_class: :"Test Exception",
+                error_message: "Some Exception",
+                controller: "some_controller",
+                exception: @exception,
+                context: {
+                  timestamp: Time.now.to_i,
+                  error_class: "StandardError",
+                  server: "invoca_fe98",
+                  exception_context: { "SERVER_NAME" => "exceptional.com" },
+                  scm_revision: "5b24eac37aaa91f5784901e9aabcead36fd9df82",
+                  notes: "this is used by a test",
+                  user_details: { "username" => "jsmith" },
+                  request: {
+                    "params" => { "advertiser_id" => 435, "controller" => "some_controller" },
+                    "rails_root" => "Rails.root not defined. Is this a test environment?",
+                    "url" => "host/path"
+                  },
+                  session: {
+                    "key" => nil,
+                    "data" => { "username" => "jsmith" }
+                  },
+                  environment: {
+                    "SERVER_NAME" => "exceptional.com"
+                  },
+                  backtrace: [
+                    "test/unit/exception_handling_test.rb:847:in `exception_1'",
+                    "test/unit/exception_handling_test.rb:455:in `block (4 levels) in <class:ExceptionHandlingTest>'"
+                  ],
+                  event_response: "Event successfully received",
+                  log_context: { "log_source" => "gem/listen", "cuid" => "AA12BC34DE" }
+                }
               }
-            }
-            assert_equal_with_diff expected_data, honeybadger_data
+              assert_equal_with_diff expected_data, honeybadger_data
+            end
+
+            should "send error details and relevant context data to Honeybadger with empty log_context" do
+              honeybadger_data = nil
+              mock(Honeybadger).notify.with_any_args do |data|
+                honeybadger_data = data
+              end
+              log_context = { }
+              ExceptionHandling.log_error(@exception, @exception_context, @controller, **log_context) do |data|
+                data[:scm_revision] = "5b24eac37aaa91f5784901e9aabcead36fd9df82"
+                data[:user_details] = { username: "jsmith" }
+                data[:event_response] = "Event successfully received"
+                data[:other_section] = "This should not be included in the response"
+              end
+
+              expected_data = {
+                error_class: :"Test Exception",
+                error_message: "Some Exception",
+                controller: "some_controller",
+                exception: @exception,
+                context: {
+                  timestamp: Time.now.to_i,
+                  error_class: "StandardError",
+                  server: "invoca_fe98",
+                  exception_context: { "SERVER_NAME" => "exceptional.com" },
+                  scm_revision: "5b24eac37aaa91f5784901e9aabcead36fd9df82",
+                  notes: "this is used by a test",
+                  user_details: { "username" => "jsmith" },
+                  request: {
+                    "params" => { "advertiser_id" => 435, "controller" => "some_controller" },
+                    "rails_root" => "Rails.root not defined. Is this a test environment?",
+                    "url" => "host/path"
+                  },
+                  session: {
+                    "key" => nil,
+                    "data" => { "username" => "jsmith" }
+                  },
+                  environment: {
+                    "SERVER_NAME" => "exceptional.com"
+                  },
+                  backtrace: [
+                               "test/unit/exception_handling_test.rb:847:in `exception_1'",
+                               "test/unit/exception_handling_test.rb:455:in `block (4 levels) in <class:ExceptionHandlingTest>'"
+                             ],
+                  event_response: "Event successfully received"
+                }
+              }
+              assert_equal_with_diff expected_data, honeybadger_data
+            end
           end
 
           context "with post_log_error_hook set" do


### PR DESCRIPTION
## [2.5.0] - Unreleased
### Added
- The `**log_context` passed to `log_error`/`log_warning`/`log_info` is now passed into `Honeybadger.notify()`, in `context: { log_context: ... }`.


- Also shut up test warnings from running `ruby -w` and renamed a constant to ALLOWLIST.