### PR TITLE
Tech 4626 log warnings at warning severity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ Inspired by [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 Note: this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.6.0] - Unreleased
+### Changed
+- Calling `log_warning` will now log with Severity::WARNING rather than FATAL.
+- Reordered the logging to put the exception class next to the message.
+
 ## [2.5.0] - 2020-08-19
 ### Added
 - The `**log_context` passed to `log_error`/`log_warning`/`log_info` is now
@@ -37,6 +42,7 @@ Note: this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0
 ### Changed
 - No longer depends on hobo_support. Uses invoca-utils 0.3 instead.
 
+[2.6.0]: https://github.com/Invoca/exception_handling/compare/v2.5.0...v2.6.0
 [2.5.0]: https://github.com/Invoca/exception_handling/compare/v2.4.4...v2.5.0
 [2.4.4]: https://github.com/Invoca/exception_handling/compare/v2.4.3...v2.4.4
 [2.4.3]: https://github.com/Invoca/exception_handling/compare/v2.4.2...v2.4.3

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,7 +8,7 @@ GIT
 PATH
   remote: .
   specs:
-    exception_handling (2.5.0)
+    exception_handling (2.6.0)
       actionmailer (>= 4.2, < 7.0)
       actionpack (>= 4.2, < 7.0)
       activesupport (>= 4.2, < 7.0)
@@ -68,7 +68,7 @@ GEM
     invoca-utils (0.4.1)
     jaro_winkler (1.5.3)
     json (2.3.1)
-    loofah (2.6.0)
+    loofah (2.7.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
     mail (2.7.1)

--- a/lib/exception_handling.rb
+++ b/lib/exception_handling.rb
@@ -222,7 +222,13 @@ module ExceptionHandling # never included
     #
     def write_exception_to_log(ex, exception_context, timestamp, log_context = {})
       ActiveSupport::Deprecation.silence do
-        ExceptionHandling.logger.fatal("\nExceptionHandlingError (Error:#{timestamp}) #{ex.class} #{exception_context} (#{encode_utf8(ex.message.to_s)}):\n  " + clean_backtrace(ex).join("\n  ") + "\n\n", log_context)
+        log_message = "\nExceptionHandlingError (Error:#{timestamp}) #{ex.class} #{exception_context} (#{encode_utf8(ex.message.to_s)}):\n  " + clean_backtrace(ex).join("\n  ") + "\n\n"
+
+        if ex.is_a?(Warning)
+          ExceptionHandling.logger.warn(log_message, log_context)
+        else
+          ExceptionHandling.logger.fatal(log_message, log_context)
+        end
       end
     end
 

--- a/lib/exception_handling.rb
+++ b/lib/exception_handling.rb
@@ -222,12 +222,12 @@ module ExceptionHandling # never included
     #
     def write_exception_to_log(ex, exception_context, timestamp, log_context = {})
       ActiveSupport::Deprecation.silence do
-        log_message = "\nExceptionHandlingError (Error:#{timestamp}) #{ex.class} #{exception_context} (#{encode_utf8(ex.message.to_s)}):\n  " + clean_backtrace(ex).join("\n  ") + "\n\n"
+        log_message = "#{exception_context}\n#{ex.class}: (#{encode_utf8(ex.message.to_s)}):\n  " + clean_backtrace(ex).join("\n  ") + "\n\n"
 
         if ex.is_a?(Warning)
-          ExceptionHandling.logger.warn(log_message, log_context)
+          ExceptionHandling.logger.warn("\nExceptionHandlingWarning (Warning:#{timestamp}) #{log_message}", log_context)
         else
-          ExceptionHandling.logger.fatal(log_message, log_context)
+          ExceptionHandling.logger.fatal("\nExceptionHandlingError (Error:#{timestamp}) #{log_message}", log_context)
         end
       end
     end

--- a/lib/exception_handling/version.rb
+++ b/lib/exception_handling/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ExceptionHandling
-  VERSION = '2.5.0'
+  VERSION = '2.6.0'
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -33,8 +33,12 @@ class LoggerStub
     clear
   end
 
+  def debug(message, log_context = {})
+    logged << { message: message, context: log_context, severity: 'DEBUG' }
+  end
+
   def info(message, log_context = {})
-    logged << { message: message, context: log_context }
+    logged << { message: message, context: log_context, severity: 'INFO' }
   end
 
   def warn(message, log_context = {})

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -38,11 +38,11 @@ class LoggerStub
   end
 
   def warn(message, log_context = {})
-    logged << { message: message, context: log_context }
+    logged << { message: message, context: log_context, severity: 'WARN' }
   end
 
   def fatal(message, log_context = {})
-    logged << { message: message, context: log_context }
+    logged << { message: message, context: log_context, severity: 'FATAL' }
   end
 
   def clear

--- a/test/unit/exception_handling_test.rb
+++ b/test/unit/exception_handling_test.rb
@@ -185,6 +185,20 @@ class ExceptionHandlingTest < ActiveSupport::TestCase
       end
     end
 
+    context "#write_exception_to_log" do
+      should "log warnings with Severity::WARNING" do
+        warning = ExceptionHandling::Warning.new('This is a Warning')
+        ExceptionHandling.write_exception_to_log(warning, '', Time.now.to_i, service_name: 'exception_handling')
+        assert_equal logged_excluding_reload_filter.last[:severity], 'WARN'
+      end
+
+      should "log everything else with Severity::FATAL" do
+        error = RuntimeError.new('This is a runtime error')
+        ExceptionHandling.write_exception_to_log(error, '', Time.now.to_i, service_name: 'exception_handling')
+        assert_equal logged_excluding_reload_filter.last[:severity], 'FATAL'
+      end
+    end
+
     context "configuration with custom_data_hook or post_log_error_hook" do
       teardown do
         ExceptionHandling.custom_data_hook = nil

--- a/test/unit/exception_handling_test.rb
+++ b/test/unit/exception_handling_test.rb
@@ -373,7 +373,7 @@ class ExceptionHandlingTest < ActiveSupport::TestCase
 
         if ActionView::VERSION::MAJOR >= 5
           should "log an exception with call stack if an ActionView template exception is raised." do
-            mock(ExceptionHandling.logger).fatal(/\(Error:\d+\) ActionView::Template::Error  \(blah\):\n /, anything)
+            mock(ExceptionHandling.logger).fatal(/\(Error:\d+\) \nActionView::Template::Error: \(blah\):\n /, anything)
             ExceptionHandling.ensure_safe do
               begin
                 # Rails 5 made the switch from ActionView::TemplateError taking in the original exception
@@ -386,7 +386,7 @@ class ExceptionHandlingTest < ActiveSupport::TestCase
           end
         else
           should "log an exception with call stack if an ActionView template exception is raised." do
-            mock(ExceptionHandling.logger).fatal(/\(Error:\d+\) ActionView::Template::Error  \(blah\):\n /, anything)
+            mock(ExceptionHandling.logger).fatal(/\(Error:\d+\) \nActionView::Template::Error: \(blah\):\n /, anything)
             ExceptionHandling.ensure_safe { raise ActionView::TemplateError.new({}, ArgumentError.new("blah")) }
           end
         end
@@ -409,7 +409,7 @@ class ExceptionHandlingTest < ActiveSupport::TestCase
         end
 
         should "allow a message to be appended to the error when logged." do
-          mock(ExceptionHandling.logger).fatal(/mooo \(blah\):\n.*exception_handling_test\.rb/, anything)
+          mock(ExceptionHandling.logger).fatal(/mooo\nArgumentError: \(blah\):\n.*exception_handling_test\.rb/, anything)
           b = ExceptionHandling.ensure_safe("mooo") { raise ArgumentError, "blah" }
           assert_nil b
         end
@@ -417,7 +417,7 @@ class ExceptionHandlingTest < ActiveSupport::TestCase
         should "only rescue StandardError and descendents" do
           assert_raise(Exception) { ExceptionHandling.ensure_safe("mooo") { raise Exception } }
 
-          mock(ExceptionHandling.logger).fatal(/mooo \(blah\):\n.*exception_handling_test\.rb/, anything)
+          mock(ExceptionHandling.logger).fatal(/mooo\nStandardError: \(blah\):\n.*exception_handling_test\.rb/, anything)
 
           b = ExceptionHandling.ensure_safe("mooo") { raise StandardError, "blah" }
           assert_nil b
@@ -448,7 +448,7 @@ class ExceptionHandlingTest < ActiveSupport::TestCase
         end
 
         should "allow a message to be appended to the error when logged." do
-          mock(ExceptionHandling.logger).fatal(/mooo \(blah\):\n.*exception_handling_test\.rb/, anything)
+          mock(ExceptionHandling.logger).fatal(/mooo\nArgumentError: \(blah\):\n.*exception_handling_test\.rb/, anything)
           b = ExceptionHandling.ensure_completely_safe("mooo") { raise ArgumentError, "blah" }
           assert_nil b
         end
@@ -505,7 +505,7 @@ class ExceptionHandlingTest < ActiveSupport::TestCase
           ExceptionHandling.ensure_escalation("ensure context") { raise ArgumentError, "first_test_exception" }
 
           assert_match(/ArgumentError.*first_test_exception/, log_fatals[0].first)
-          assert_match(/safe_email_deliver.*Delivery Error/, log_fatals[1].first)
+          assert_match(/safe_email_deliver.*Delivery Error/m, log_fatals[1].first)
 
           assert_equal 2, log_fatals.size, log_fatals.inspect
 
@@ -575,7 +575,7 @@ class ExceptionHandlingTest < ActiveSupport::TestCase
         should "include the timestamp when the exception is logged" do
           capture_notifications
 
-          mock(ExceptionHandling.logger).fatal(/\(Error:517033020\) ArgumentError context \(blah\):\n.*exception_handling_test\.rb/, anything)
+          mock(ExceptionHandling.logger).fatal(/\(Error:517033020\) context\nArgumentError: \(blah\):\n.*exception_handling_test\.rb/, anything)
           b = ExceptionHandling.ensure_safe("context") { raise ArgumentError, "blah" }
           assert_nil b
 

--- a/test/unit/exception_handling_test.rb
+++ b/test/unit/exception_handling_test.rb
@@ -149,6 +149,11 @@ class ExceptionHandlingTest < ActiveSupport::TestCase
         assert_not_empty logged_excluding_reload_filter.last[:context]
         assert_equal logged_excluding_reload_filter.last[:context], service_name: 'exception_handling'
       end
+
+      should "log with Severity::FATAL" do
+        ExceptionHandling.log_error('This is a Warning', service_name: 'exception_handling')
+        assert_equal logged_excluding_reload_filter.last[:severity], 'FATAL'
+      end
     end
 
     context "#log_warning" do
@@ -165,28 +170,43 @@ class ExceptionHandlingTest < ActiveSupport::TestCase
         assert_not_empty logged_excluding_reload_filter.last[:context]
         assert_equal logged_excluding_reload_filter.last[:context], service_name: 'exception_handling'
       end
+
+      should "log with Severity::WARN" do
+        ExceptionHandling.log_warning('This is a Warning', service_name: 'exception_handling')
+        assert_equal logged_excluding_reload_filter.last[:severity], 'WARN'
+      end
     end
 
     context "#log_info" do
       should "take in additional key word args as logging context and pass them to the logger" do
-        ExceptionHandling.log_warning('This is an Info', service_name: 'exception_handling')
+        ExceptionHandling.log_info('This is an Info', service_name: 'exception_handling')
         assert_match(/This is an Info/, logged_excluding_reload_filter.last[:message])
         assert_not_empty logged_excluding_reload_filter.last[:context]
         assert_equal logged_excluding_reload_filter.last[:context], service_name: 'exception_handling'
+      end
+
+      should "log with Severity::INFO" do
+        ExceptionHandling.log_info('This is a Warning', service_name: 'exception_handling')
+        assert_equal logged_excluding_reload_filter.last[:severity], 'INFO'
       end
     end
 
     context "#log_debug" do
       should "take in additional key word args as logging context and pass them to the logger" do
-        ExceptionHandling.log_warning('This is a Debug', service_name: 'exception_handling')
+        ExceptionHandling.log_debug('This is a Debug', service_name: 'exception_handling')
         assert_match(/This is a Debug/, logged_excluding_reload_filter.last[:message])
         assert_not_empty logged_excluding_reload_filter.last[:context]
         assert_equal logged_excluding_reload_filter.last[:context], service_name: 'exception_handling'
       end
+
+      should "log with Severity::DEBUG" do
+        ExceptionHandling.log_debug('This is a Warning', service_name: 'exception_handling')
+        assert_equal logged_excluding_reload_filter.last[:severity], 'DEBUG'
+      end
     end
 
     context "#write_exception_to_log" do
-      should "log warnings with Severity::WARNING" do
+      should "log warnings with Severity::WARN" do
         warning = ExceptionHandling::Warning.new('This is a Warning')
         ExceptionHandling.write_exception_to_log(warning, '', Time.now.to_i, service_name: 'exception_handling')
         assert_equal logged_excluding_reload_filter.last[:severity], 'WARN'


### PR DESCRIPTION
## [2.6.0] - Unreleased
### Changed
- Calling `log_warning` will now log with Severity::WARNING rather than FATAL.
- Reordered the logging to put the exception class next to the message.

[2.6.0]: https://github.com/Invoca/exception_handling/compare/v2.5.0...v2.6.0