### PR TITLE
no-jira: always set merged log context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,11 @@ Inspired by [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 Note: this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [2.6.0] - Unreleased
+## [2.6.1] - Unreleased
+### Fixed
+- Fixed honeybadger_context_data to always merge `current_context_for_thread`, even if `log_context:` is passed as `nil`.
+
+## [2.6.0] - 2020-08-26
 ### Changed
 - Calling `log_warning` will now log with Severity::WARNING rather than FATAL.
 - Reordered the logging to put the exception class next to the message.
@@ -42,6 +46,7 @@ Note: this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0
 ### Changed
 - No longer depends on hobo_support. Uses invoca-utils 0.3 instead.
 
+[2.6.1]: https://github.com/Invoca/exception_handling/compare/v2.6.0...v2.6.1
 [2.6.0]: https://github.com/Invoca/exception_handling/compare/v2.5.0...v2.6.0
 [2.5.0]: https://github.com/Invoca/exception_handling/compare/v2.4.4...v2.5.0
 [2.4.4]: https://github.com/Invoca/exception_handling/compare/v2.4.3...v2.4.4

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,7 +8,7 @@ GIT
 PATH
   remote: .
   specs:
-    exception_handling (2.6.0)
+    exception_handling (2.6.1)
       actionmailer (>= 4.2, < 7.0)
       actionpack (>= 4.2, < 7.0)
       activesupport (>= 4.2, < 7.0)
@@ -55,7 +55,7 @@ GEM
     builder (3.2.3)
     coderay (1.1.2)
     concurrent-ruby (1.1.5)
-    contextual_logger (0.9.1)
+    contextual_logger (0.10.0)
       activesupport
       json
     crass (1.0.6)

--- a/lib/exception_handling/exception_info.rb
+++ b/lib/exception_handling/exception_info.rb
@@ -57,9 +57,8 @@ module ExceptionHandling
       @timestamp = timestamp
       @controller = controller || controller_from_context(exception_context)
       @data_callback = data_callback
-      @merged_log_context = if log_context # merge into the surrounding context just like ContextualLogger does when logging
-                              ExceptionHandling.logger.current_context_for_thread.deep_merge(log_context)
-                            end
+      # merge into the surrounding context just like ContextualLogger does when logging
+      @merged_log_context = ExceptionHandling.logger.current_context_for_thread.deep_merge(log_context || {})
     end
 
     def data
@@ -273,13 +272,11 @@ module ExceptionHandling
       data[:exception_context] = deep_clean_hash(@exception_context) if @exception_context.present?
       data[:log_context] = @merged_log_context
       unstringify_sections(data)
-      context_data = HONEYBADGER_CONTEXT_SECTIONS.reduce({}) do |context, section|
+      HONEYBADGER_CONTEXT_SECTIONS.each_with_object({}) do |section, context|
         if data[section].present?
           context[section] = data[section]
         end
-        context
       end
-      context_data
     end
   end
 end

--- a/lib/exception_handling/version.rb
+++ b/lib/exception_handling/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ExceptionHandling
-  VERSION = '2.6.0'
+  VERSION = '2.6.1'
 end


### PR DESCRIPTION
## [2.6.1] - Unreleased
### Fixed
- Fixed honeybadger_context_data to always merge `current_context_for_thread`, even if `log_context:` is passed as `nil`.