### PR TITLE
TECH-5030 add honeybadger grouping option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Inspired by [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 Note: this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.8.1] - Unreleased
+### Added
+- Option to set Honeybadger `controller` via `log_context` in `HoneyBadger.notify()`.
+
 ## [2.8.0] - Unreleased
 ### Deprecated
 - Deprecated Email Escalation Methods: `escalate_to_production_support`, `escalate_error`, `escalate_warning`, `ensure_escalation`
@@ -56,6 +60,7 @@ Note: this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0
 ### Changed
 - No longer depends on hobo_support. Uses invoca-utils 0.3 instead.
 
+[2.8.1]: https://github.com/Invoca/exception_handling/compare/v2.8.0...v2.8.1
 [2.8.0]: https://github.com/Invoca/exception_handling/compare/v2.7.0...v2.8.0
 [2.7.0]: https://github.com/Invoca/exception_handling/compare/v2.6.1...v2.7.0
 [2.6.1]: https://github.com/Invoca/exception_handling/compare/v2.6.0...v2.6.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ Note: this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0
 
 ## [2.8.1] - Unreleased
 ### Added
-- Option to set Honeybadger `controller` via `log_context` in `HoneyBadger.notify()`.
+- If the `log_context` key `honeybadger_grouping:` is set, pass that value to the `controller:` keyword argument of `HoneyBadger.notify`.
 
 ## [2.8.0] - Unreleased
 ### Deprecated

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,7 +8,7 @@ GIT
 PATH
   remote: .
   specs:
-    exception_handling (2.8.1.pre.1)
+    exception_handling (2.8.1)
       actionmailer (>= 4.2, < 7.0)
       actionpack (>= 4.2, < 7.0)
       activesupport (>= 4.2, < 7.0)
@@ -131,7 +131,7 @@ GEM
     tzinfo (1.2.8)
       thread_safe (~> 0.1)
     unicode-display_width (1.6.0)
-    zeitwerk (2.4.1)
+    zeitwerk (2.4.2)
 
 PLATFORMS
   ruby

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,7 +8,7 @@ GIT
 PATH
   remote: .
   specs:
-    exception_handling (2.8.1.pre.0)
+    exception_handling (2.8.1.pre.1)
       actionmailer (>= 4.2, < 7.0)
       actionpack (>= 4.2, < 7.0)
       activesupport (>= 4.2, < 7.0)
@@ -70,7 +70,7 @@ GEM
     invoca-utils (0.4.1)
     jaro_winkler (1.5.3)
     json (2.3.1)
-    loofah (2.7.0)
+    loofah (2.8.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
     mail (2.7.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,7 +8,7 @@ GIT
 PATH
   remote: .
   specs:
-    exception_handling (2.8.0)
+    exception_handling (2.8.1.pre.0)
       actionmailer (>= 4.2, < 7.0)
       actionpack (>= 4.2, < 7.0)
       activesupport (>= 4.2, < 7.0)
@@ -61,7 +61,7 @@ GEM
       json
     crass (1.0.6)
     diff-lcs (1.4.4)
-    erubi (1.9.0)
+    erubi (1.10.0)
     eventmachine (1.2.7)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
@@ -128,10 +128,10 @@ GEM
       power_assert
     thor (1.0.1)
     thread_safe (0.3.6)
-    tzinfo (1.2.7)
+    tzinfo (1.2.8)
       thread_safe (~> 0.1)
     unicode-display_width (1.6.0)
-    zeitwerk (2.4.0)
+    zeitwerk (2.4.1)
 
 PLATFORMS
   ruby

--- a/lib/exception_handling/exception_info.rb
+++ b/lib/exception_handling/exception_info.rb
@@ -82,9 +82,10 @@ module ExceptionHandling
     end
 
     def controller_name
-      @controller_name ||= if @controller
-                             @controller.request.parameters.with_indifferent_access[:controller]
-                           end.to_s
+      @controller_name ||= (
+        @merged_log_context[:honeybadger_grouping] ||
+          (@controller && @controller.request.parameters.with_indifferent_access[:controller])
+      ).to_s
     end
 
     private

--- a/lib/exception_handling/version.rb
+++ b/lib/exception_handling/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ExceptionHandling
-  VERSION = '2.8.1.pre.0'
+  VERSION = '2.8.1.pre.1'
 end

--- a/lib/exception_handling/version.rb
+++ b/lib/exception_handling/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ExceptionHandling
-  VERSION = '2.8.0'
+  VERSION = '2.8.1.pre.0'
 end

--- a/lib/exception_handling/version.rb
+++ b/lib/exception_handling/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ExceptionHandling
-  VERSION = '2.8.1.pre.1'
+  VERSION = '2.8.1'
 end

--- a/spec/unit/exception_handling/exception_info_spec.rb
+++ b/spec/unit/exception_handling/exception_info_spec.rb
@@ -361,6 +361,26 @@ module ExceptionHandling
         }
       end
 
+      it "returns honeybadger_grouping from the log context" do
+        allow(ExceptionHandling.logger).to receive(:current_context_for_thread).and_return({ honeybadger_grouping: 'Group 1' })
+        exception_info = ExceptionInfo.new(@exception, @exception_context, @timestamp)
+
+        expect(exception_info.controller_name).to eq('Group 1')
+      end
+
+      it "returns honeybadger_grouping from log context even if controller is defined" do
+        allow(ExceptionHandling.logger).to receive(:current_context_for_thread).and_return({ honeybadger_grouping: 'Group 1' })
+
+        env         = { server:     'fe98' }
+        parameters  = { controller: 'some_controller' }
+        session     = { username:   'smith' }
+        request_uri = "host/path"
+        controller  = create_dummy_controller(env, parameters, session, request_uri)
+        exception_info = ExceptionInfo.new(@exception, @exception_context, @timestamp, controller: controller)
+
+        expect(exception_info.controller_name).to eq('Group 1')
+      end
+
       it "return controller_name when controller is present" do
         env         = { server:     'fe98' }
         parameters  = { controller: 'some_controller' }


### PR DESCRIPTION
`Honeybadger#notify` uses the `:controller` keyword argument to help group exceptions ([Docs](https://docs.honeybadger.io/lib/javascript/guides/customizing-error-grouping.html))

In this PR, we are adding the ability to group exceptions by passing in `honeybadger_grouping` to the LoggerContext which will then get passed to Honeybadger via the `:controller` keyword.