### PR TITLE
TECH-7286: update contextual logger version to include ruby 3 support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Inspired by [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 Note: this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.11.1] - Unreleased
+### Fixed
+- Fixed bug in ruby 3+ where `contextual_logger` was missing ruby 3+ support
+
 ## [2.11.0] - 2022-03-29
 ### Added
 - Added support for rails 2.7 and 3+
@@ -79,6 +83,9 @@ Note: this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0
 ### Changed
 - No longer depends on hobo_support. Uses invoca-utils 0.3 instead.
 
+[2.11.1]: https://github.com/Invoca/exception_handling/compare/v2.11.0...v2.11.1
+[2.11.0]: https://github.com/Invoca/exception_handling/compare/v2.10.0...v2.11.0
+[2.10.0]: https://github.com/Invoca/exception_handling/compare/v2.9.0...v2.10.0
 [2.9.0]: https://github.com/Invoca/exception_handling/compare/v2.8.1...v2.9.0
 [2.8.1]: https://github.com/Invoca/exception_handling/compare/v2.8.0...v2.8.1
 [2.8.0]: https://github.com/Invoca/exception_handling/compare/v2.7.0...v2.8.0

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,11 +1,11 @@
 PATH
   remote: .
   specs:
-    exception_handling (2.11.0)
+    exception_handling (2.11.1)
       actionmailer (>= 5.2, < 7.0)
       actionpack (>= 5.2, < 7.0)
       activesupport (>= 5.2, < 7.0)
-      contextual_logger (~> 0.7)
+      contextual_logger (~> 1.0)
       escalate (~> 0.3)
       eventmachine (~> 1.0)
       invoca-utils (~> 0.3)
@@ -52,7 +52,7 @@ GEM
     byebug (11.1.3)
     coderay (1.1.2)
     concurrent-ruby (1.1.10)
-    contextual_logger (0.11.0)
+    contextual_logger (1.0.0)
       activesupport
       json
     crass (1.0.6)
@@ -67,7 +67,6 @@ GEM
     i18n (1.10.0)
       concurrent-ruby (~> 1.0)
     invoca-utils (0.4.1)
-    io-wait (0.2.1)
     jaro_winkler (1.5.3)
     json (2.6.1)
     loofah (2.15.0)
@@ -79,8 +78,7 @@ GEM
     mini_mime (1.1.2)
     mini_portile2 (2.8.0)
     minitest (5.15.0)
-    net-protocol (0.1.2)
-      io-wait
+    net-protocol (0.1.3)
       timeout
     net-smtp (0.3.1)
       digest

--- a/exception_handling.gemspec
+++ b/exception_handling.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'actionmailer',      '>= 5.2', '< 7.0'
   spec.add_dependency 'actionpack',        '>= 5.2', '< 7.0'
   spec.add_dependency 'activesupport',     '>= 5.2', '< 7.0'
-  spec.add_dependency 'contextual_logger', '~> 0.7'
+  spec.add_dependency 'contextual_logger', '~> 1.0'
   spec.add_dependency 'escalate',          '~> 0.3'
   spec.add_dependency 'eventmachine',      '~> 1.0'
   spec.add_dependency 'invoca-utils',      '~> 0.3'

--- a/lib/exception_handling/version.rb
+++ b/lib/exception_handling/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ExceptionHandling
-  VERSION = '2.11.0'
+  VERSION = '2.11.1'
 end


### PR DESCRIPTION
## [2.11.1] - Unreleased
### Fixed
- Fixed bug in ruby 3+ where `contextual_logger` was missing ruby 3+ support