### PR TITLE
TECH-7568 provide cleaned backtrace to honeybadger notification

### DIFF
--- a/lib/exception_handling.rb
+++ b/lib/exception_handling.rb
@@ -271,7 +271,8 @@ module ExceptionHandling # never included
                                     error_message: exception.message.to_s,
                                     exception:     exception,
                                     context:       exception_info.honeybadger_context_data,
-                                    controller:    exception_info.controller_name)
+                                    controller:    exception_info.controller_name,
+                                    backtrace:     exception_info.honeybadger_context_data[:backtrace])
       response ? :success : :failure
     rescue Exception => ex
       warn("ExceptionHandling.send_exception_to_honeybadger rescued exception while logging #{exception_info.exception_context}:\n#{exception.class}: #{exception.message}:\n#{ex.class}: #{ex.message}\n#{ex.backtrace.join("\n")}")

--- a/spec/unit/exception_handling_spec.rb
+++ b/spec/unit/exception_handling_spec.rb
@@ -718,7 +718,11 @@ describe ExceptionHandling do
                   ],
                   event_response: "Event successfully received",
                   log_context: { "service_name" => "bin/console", "region" => "AWS-us-east-1", "log_source" => "gem/listen" }
-                }
+                },
+                backtrace: [
+                  "spec/unit/exception_handling_spec.rb:847:in `exception_1'",
+                  "spec/unit/exception_handling_spec.rb:455:in `block (4 levels) in <class:ExceptionHandlingTest>'"
+                ]
               }
               expect(honeybadger_data).to eq(expected_data)
             end
@@ -763,11 +767,15 @@ describe ExceptionHandling do
                     "SERVER_NAME" => "exceptional.com"
                   },
                   backtrace: [
-                               "spec/unit/exception_handling_spec.rb:847:in `exception_1'",
-                               "spec/unit/exception_handling_spec.rb:455:in `block (4 levels) in <class:ExceptionHandlingTest>'"
-                             ],
+                    "spec/unit/exception_handling_spec.rb:847:in `exception_1'",
+                    "spec/unit/exception_handling_spec.rb:455:in `block (4 levels) in <class:ExceptionHandlingTest>'"
+                  ],
                   event_response: "Event successfully received"
-                }
+                },
+                backtrace: [
+                  "spec/unit/exception_handling_spec.rb:847:in `exception_1'",
+                  "spec/unit/exception_handling_spec.rb:455:in `block (4 levels) in <class:ExceptionHandlingTest>'"
+                ]
               }
               expect(honeybadger_data).to eq(expected_data)
             end


### PR DESCRIPTION
Although we clean the backtrace for [logging our exception handling](https://github.com/Invoca/exception_handling/blob/52df6e4ceacd67cb56e5bc6656d1c57ec0452797/lib/exception_handling.rb#L231), and we also clean the backtrace for [the exception context we send to Honeybadger](https://github.com/Invoca/exception_handling/blob/ab6b02de0cf1b60ab50077e606609cfe7d44a26c/lib/exception_handling/exception_info.rb#L103), we don't yet provide this cleaned backtrace to Honeybadger, in order for it to correctly categorize the notification based on the cleaned backtrace's source file and line number.

The purpose of this change is to begin passing that additional parameter - getting it from the prepared context and providing it as a notification parameter.