### PR TITLE
Tech 7841 customize ringswitch logger honeybadger notifications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Inspired by [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 Note: this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [2.11.4.gfaza.1] - Unreleased
+## [2.12.0.gfaza.1] - Unreleased
 ### Added
 - Support for passing additional Honeybadger configuration parameters
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Inspired by [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 Note: this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.11.4.gfaza.1] - Unreleased
+### Added
+- Support for passing additional Honeybadger configuration parameters
+
 ## [2.11.3] - 2022-04-07
 ### Fixed
 - Fixed bug in ruby 2.7+ where `digest` was not required by default

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    exception_handling (2.11.3)
+    exception_handling (2.11.4.gfaza.1)
       actionmailer (>= 5.2, < 7.0)
       actionpack (>= 5.2, < 7.0)
       activesupport (>= 5.2, < 7.0)
@@ -68,7 +68,7 @@ GEM
       concurrent-ruby (~> 1.0)
     invoca-utils (0.4.1)
     jaro_winkler (1.5.3)
-    json (2.6.1)
+    json (2.6.2)
     loofah (2.15.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
@@ -136,7 +136,7 @@ GEM
       power_assert
     thor (1.0.1)
     thread_safe (0.3.6)
-    timeout (0.2.0)
+    timeout (0.3.0)
     tzinfo (1.2.9)
       thread_safe (~> 0.1)
     unicode-display_width (1.6.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    exception_handling (2.11.4.gfaza.1)
+    exception_handling (2.12.0.gfaza.1)
       actionmailer (>= 5.2, < 7.0)
       actionpack (>= 5.2, < 7.0)
       activesupport (>= 5.2, < 7.0)

--- a/lib/exception_handling.rb
+++ b/lib/exception_handling.rb
@@ -293,7 +293,11 @@ module ExceptionHandling # never included
       Bundler.require(:honeybadger)
       Honeybadger.configure do |config_klass|
         config.each do |k, v|
-          config_klass.send(:"#{k}=", v)
+          if k == :before_notify
+            config_klass.send(k, v)
+          else
+            config_klass.send(:"#{k}=", v)
+          end
         end
       end
     end

--- a/lib/exception_handling/version.rb
+++ b/lib/exception_handling/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ExceptionHandling
-  VERSION = '2.11.3'
+  VERSION = '2.11.4.gfaza.1'
 end

--- a/lib/exception_handling/version.rb
+++ b/lib/exception_handling/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ExceptionHandling
-  VERSION = '2.11.4.gfaza.1'
+  VERSION = '2.12.0.gfaza.1'
 end


### PR DESCRIPTION
[TECH-7841](https://invoca.atlassian.net/browse/TECH-7841) - Part 1 of 3

Hello again, James!

As [discussed](https://invoca.slack.com/archives/CRGB17J59/p1656454503520629?thread_ts=1655913603.008009&cid=CRGB17J59), this change is to tunnel a Honeybadger `before_notify` configuration from `web` through to `exception_handling`.