### PR TITLE
Tech 8467 remove prefix from default metric name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Inspired by [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 Note: this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.13.0] - Unreleased
+### Added
+- Added an option for removing the 'exception_handling.' prefix from metric names in ExceptionHandling::default_metric_name
+
 ## [2.12.0] - 2022-08-04
 ### Added
 - Support for passing additional Honeybadger configuration parameters
@@ -95,6 +99,7 @@ Note: this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0
 ### Changed
 - No longer depends on hobo_support. Uses invoca-utils 0.3 instead.
 
+[2.13.0]: https://github.com/Invoca/exception_handling/compare/v2.12.0...v2.13.0
 [2.12.0]: https://github.com/Invoca/exception_handling/compare/v2.11.3...v2.12.0
 [2.11.3]: https://github.com/Invoca/exception_handling/compare/v2.11.2...v2.11.3
 [2.11.2]: https://github.com/Invoca/exception_handling/compare/v2.11.1...v2.11.2

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    exception_handling (2.12.0)
+    exception_handling (2.13.0.pre.dc.0)
       actionmailer (>= 5.2, < 7.0)
       actionpack (>= 5.2, < 7.0)
       activesupport (>= 5.2, < 7.0)

--- a/lib/exception_handling.rb
+++ b/lib/exception_handling.rb
@@ -71,7 +71,10 @@ module ExceptionHandling # never included
       EscalateCallback.register_if_configured!
     end
 
-    def default_metric_name(exception_data, exception, treat_like_warning)
+    def default_metric_name(exception_data, exception, treat_like_warning, include_prefix: true)
+      include_prefix and Deprecation3_0.deprecation_warning("the 'expection_handling.' prefix in ExceptionHandling::default_metric_name",
+                                                            "do not rely on metric names including the 'exception_handling.' prefix.")
+
       metric_name = if exception_data['metric_name']
                       exception_data['metric_name']
                     elsif exception.is_a?(ExceptionHandling::Warning)
@@ -83,7 +86,7 @@ module ExceptionHandling # never included
                       "exception"
                     end
 
-      "exception_handling.#{metric_name}"
+      "#{'exception_handling.' if include_prefix}#{metric_name}"
     end
 
     def default_honeybadger_metric_name(honeybadger_status)

--- a/lib/exception_handling/version.rb
+++ b/lib/exception_handling/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ExceptionHandling
-  VERSION = '2.12.0'
+  VERSION = '2.13.0.pre.dc.0'
 end


### PR DESCRIPTION
## [2.13.0]
### Added
- Added an option for removing the 'exception_handling.' prefix from metric names in ExceptionHandling::default_metric_name