### PR TITLE
TECH-14011 use colons instead of hyphens to combine hb tag name and value from log context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Inspired by [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 **Note:** this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [3.1.1] - Unreleased
+## [3.1.1] - 2024-03-19
 ### Changed
 - Changed how the `honeybadger_tag_from_log_context` to now combine the tag name with the value using a colon `:` instead of two hyphens `--`.
   - There was a bug in Honeybadger that was preventing colons from being used in tags. However that bug is now fixed so we can use colons (which look better).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ Inspired by [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 **Note:** this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.1.1] - Unreleased
+### Changed
+- Changed how the `honeybadger_tag_from_log_context` to now combine the tag name with the value using a colon `:` instead of two hyphens `--`.
+  - There was a bug in Honeybadger that was preventing colons from being used in tags. However that bug is now fixed so we can use colons (which look better).
+
 ## [3.1.0] - 2024-03-12
 ### Added
 - Add interface for tagging exceptions sent to honeybadger with values from the log context.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    exception_handling (3.1.1)
+    exception_handling (3.1.1.pre.tstarck.1)
       activesupport (>= 5.2)
       contextual_logger (~> 1.0)
       escalate (~> 0.3)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    exception_handling (3.1.0)
+    exception_handling (3.1.1)
       activesupport (>= 5.2)
       contextual_logger (~> 1.0)
       escalate (~> 0.3)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    exception_handling (3.1.1.pre.tstarck.1)
+    exception_handling (3.1.1)
       activesupport (>= 5.2)
       contextual_logger (~> 1.0)
       escalate (~> 0.3)

--- a/lib/exception_handling.rb
+++ b/lib/exception_handling.rb
@@ -379,7 +379,7 @@ module ExceptionHandling # never included
       if @honeybadger_log_context_tags
         @honeybadger_log_context_tags.map do |tag_name, tag_path|
           if (value_from_log_context = honeybadger_context_data.dig(:log_context, *tag_path))
-            "#{tag_name}--#{value_from_log_context}"
+            "#{tag_name}:#{value_from_log_context}"
           end
         end.compact
       else

--- a/lib/exception_handling/version.rb
+++ b/lib/exception_handling/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ExceptionHandling
-  VERSION = '3.1.1'
+  VERSION = '3.1.1.pre.tstarck.1'
 end

--- a/lib/exception_handling/version.rb
+++ b/lib/exception_handling/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ExceptionHandling
-  VERSION = '3.1.0'
+  VERSION = '3.1.1'
 end

--- a/lib/exception_handling/version.rb
+++ b/lib/exception_handling/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ExceptionHandling
-  VERSION = '3.1.1.pre.tstarck.1'
+  VERSION = '3.1.1'
 end

--- a/spec/unit/exception_handling_spec.rb
+++ b/spec/unit/exception_handling_spec.rb
@@ -1091,7 +1091,7 @@ describe ExceptionHandling do
         context "when error is logged within a log context that matches the path" do
           it "notifies honeybadger with the tags from the log context" do
             ExceptionHandling.logger.with_context("kubernetes" => { "context" => "local" }) do
-              expect(Honeybadger).to receive(:notify).with(hash_including({ tags: "kubernetes_context--local" }))
+              expect(Honeybadger).to receive(:notify).with(hash_including({ tags: "kubernetes_context:local" }))
               ExceptionHandling.log_error(StandardError.new("Error"), nil)
             end
           end
@@ -1123,7 +1123,7 @@ describe ExceptionHandling do
         end
 
         it "combines all the tags from different sources" do
-          expect(Honeybadger).to receive(:notify).with(hash_including({ tags: "auto-tag inline-tag log-context--tag" }))
+          expect(Honeybadger).to receive(:notify).with(hash_including({ tags: "auto-tag inline-tag log-context:tag" }))
           ExceptionHandling.logger.with_context("inside" => { "context" => "tag" }) do
             log_error
           end
@@ -1133,7 +1133,7 @@ describe ExceptionHandling do
           let(:inline_tags) { ["auto-tag"] }
 
           it "notifies honeybadger with the set of tags" do
-            expect(Honeybadger).to receive(:notify).with(hash_including({ tags: "auto-tag log-context--tag" }))
+            expect(Honeybadger).to receive(:notify).with(hash_including({ tags: "auto-tag log-context:tag" }))
             ExceptionHandling.logger.with_context("inside" => { "context" => "tag" }) do
               log_error
             end


### PR DESCRIPTION
Switch to using colons instead of hyphens to separate tag names and values within the Honeybadger tags from log context!