### PR TITLE
non-production: set up codecov in this repo

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -6,3 +6,4 @@ on:
 jobs:
   tests:
     uses: Invoca/ruby-test-matrix-workflow/.github/workflows/ruby-test-matrix.yml@main
+    secrets: inherit

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 spec/reports/*
 gemfiles/*.lock
 pkg/
+coverage/

--- a/Gemfile
+++ b/Gemfile
@@ -15,6 +15,8 @@ gem 'rake'
 gem 'rspec'
 gem 'rspec_junit_formatter'
 gem 'rubocop'
+gem 'simplecov', '~> 0.22'
+gem 'simplecov-lcov', '~> 0.8'
 gem 'test-unit'
 
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -38,6 +38,7 @@ GEM
       activesupport
       json
     diff-lcs (1.5.1)
+    docile (1.4.1)
     drb (2.2.1)
     escalate (0.3.0)
     gem-release (2.2.2)
@@ -98,6 +99,13 @@ GEM
     rubocop-ast (1.31.3)
       parser (>= 3.3.1.0)
     ruby-progressbar (1.13.0)
+    simplecov (0.22.0)
+      docile (~> 1.1)
+      simplecov-html (~> 0.11)
+      simplecov_json_formatter (~> 0.1)
+    simplecov-html (0.13.2)
+    simplecov-lcov (0.9.0)
+    simplecov_json_formatter (0.1.4)
     stringio (3.1.0)
     test-unit (3.6.2)
       power_assert
@@ -126,6 +134,8 @@ DEPENDENCIES
   rspec
   rspec_junit_formatter
   rubocop
+  simplecov (~> 0.22)
+  simplecov-lcov (~> 0.8)
   test-unit
 
 BUNDLED WITH

--- a/gemfiles/rails_7_0.gemfile
+++ b/gemfiles/rails_7_0.gemfile
@@ -19,5 +19,7 @@ gem "base64", ">= 0.2.0"
 gem "bigdecimal", ">= 3.1"
 gem "mutex_m", ">= 0.2.0"
 gem "rails", "~> 7.0.0"
+gem "simplecov", "~> 0.22"
+gem "simplecov-lcov", "~> 0.8"
 
 gemspec path: "../"

--- a/gemfiles/rails_7_1.gemfile
+++ b/gemfiles/rails_7_1.gemfile
@@ -19,5 +19,7 @@ gem "base64", ">= 0.2.0"
 gem "bigdecimal", ">= 3.1"
 gem "mutex_m", ">= 0.2.0"
 gem "rails", "~> 7.1.0"
+gem "simplecov", "~> 0.22"
+gem "simplecov-lcov", "~> 0.8"
 
 gemspec path: "../"

--- a/gemfiles/rails_7_2.gemfile
+++ b/gemfiles/rails_7_2.gemfile
@@ -19,5 +19,7 @@ gem "base64", ">= 0.2.0"
 gem "bigdecimal", ">= 3.1"
 gem "mutex_m", ">= 0.2.0"
 gem "rails", "~> 7.2.0"
+gem "simplecov", "~> 0.22"
+gem "simplecov-lcov", "~> 0.8"
 
 gemspec path: "../"

--- a/gemfiles/rails_8_0.gemfile
+++ b/gemfiles/rails_8_0.gemfile
@@ -19,5 +19,7 @@ gem "base64", ">= 0.2.0"
 gem "bigdecimal", ">= 3.1"
 gem "mutex_m", ">= 0.2.0"
 gem "rails", "~> 8.0.0"
+gem "simplecov", "~> 0.22"
+gem "simplecov-lcov", "~> 0.8"
 
 gemspec path: "../"

--- a/spec/simplecov_helper.rb
+++ b/spec/simplecov_helper.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+unless ENV["NO_COVERAGE"] == "true"
+  require "simplecov"
+
+  SimpleCov.start do
+    add_filter "/spec/"
+    track_files "lib/**/*.rb"
+
+    if ENV["GITHUB_ACTIONS"]
+      require "simplecov-lcov"
+
+      SimpleCov::Formatter::LcovFormatter.config do |config|
+        config.report_with_single_file = true
+        config.single_report_path = "coverage/lcov.info"
+      end
+
+      formatter SimpleCov::Formatter::LcovFormatter
+    else
+      formatter SimpleCov::Formatter::HTMLFormatter
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require_relative "simplecov_helper"
+
 require 'rspec'
 require 'rspec/mocks'
 require 'rspec_junit_formatter'


### PR DESCRIPTION
## Summary

- Pass secrets: inherit to the shared ruby-test-matrix workflow call in .github/workflows/pipeline.yml so the org CODECOV_TOKEN reaches the Codecov upload step
- Add simplecov and simplecov-lcov as dev dependencies (Gemfile, per this repo's convention) and a spec/simplecov_helper.rb loaded first by spec/spec_helper.rb; on CI (GITHUB_ACTIONS) it emits lcov to coverage/lcov.info, locally it emits the HTML report
- Ignore coverage/ in .gitignore; Gemfile.lock updated

## Coverage

Measured locally with Ruby 3.1.2: 157 examples, 0 failures, Line Coverage: 93.54% (449/480). Verified GITHUB_ACTIONS=true run produces coverage/lcov.info.

No codecov.yml added since coverage is above 80%.